### PR TITLE
Filter suggestions to single child-friendly words

### DIFF
--- a/src/components/Suggestions.jsx
+++ b/src/components/Suggestions.jsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { wordClassBackgroundColours } from './mappings';
 import { Lightbulb } from 'lucide-react';
 import PropTypes from 'prop-types';
+import { filterChildFriendly } from '../utils/filterSuggestions.js';
 
 const Suggestions = ({
   sentences,
@@ -57,7 +58,9 @@ const Suggestions = ({
       combinedDB[key] = [...combinedDB[key], ...wordieDB[key]];
     });
 
-    const possibleWords = combinedDB[`${suggestedType}s`] || [];
+    const possibleWords = filterChildFriendly(
+      combinedDB[`${suggestedType}s`] || []
+    );
 
     if (possibleWords.length === 0) {
       setSuggestedWord(null);

--- a/src/spellChecker.js
+++ b/src/spellChecker.js
@@ -2,6 +2,7 @@
 
 import nspell from 'nspell';
 import dictionary from 'dictionary-en';
+import { filterChildFriendly } from './utils/filterSuggestions.js';
 
 let spell;
 
@@ -25,5 +26,6 @@ export const checkSpelling = (word) => {
 
 export const getSuggestions = (word) => {
   if (!spell) return [];
-  return spell.suggest(word);
+  const suggestions = spell.suggest(word);
+  return filterChildFriendly(suggestions);
 };

--- a/src/spellChecker.jsx
+++ b/src/spellChecker.jsx
@@ -2,6 +2,7 @@
 
 import nspell from 'nspell';
 import dictionary from 'dictionary-en';
+import { filterChildFriendly } from './utils/filterSuggestions.js';
 
 let spell;
 
@@ -25,5 +26,6 @@ export const checkSpelling = (word) => {
 
 export const getSuggestions = (word) => {
   if (!spell) return [];
-  return spell.suggest(word);
+  const suggestions = spell.suggest(word);
+  return filterChildFriendly(suggestions);
 };

--- a/src/utils/dictionary.js
+++ b/src/utils/dictionary.js
@@ -3,6 +3,8 @@
 // fetching part-of-speech information and predictive suggestions.
 
 // Fetch the part of speech for a word. Returns 'unknown' if not found.
+import { filterChildFriendly } from './filterSuggestions.js';
+
 export const fetchWordClass = async (word) => {
   if (!word) return 'unknown';
   try {
@@ -40,7 +42,7 @@ export const fetchSuggestions = async (fragment) => {
     );
     if (!response.ok) return [];
     const data = await response.json();
-    return data.map((item) => item.word);
+    return filterChildFriendly(data.map((item) => item.word));
   } catch {
     return [];
   }

--- a/src/utils/filterSuggestions.js
+++ b/src/utils/filterSuggestions.js
@@ -1,0 +1,20 @@
+export const inappropriateWords = [
+  'sex',
+  'porn',
+  'drugs',
+  'alcohol',
+  'violence',
+  'kill',
+  'murder',
+  'damn',
+  'hell',
+  'shit'
+];
+
+export const filterChildFriendly = (words) => {
+  return words.filter(
+    (word) =>
+      /^[a-zA-Z]+$/.test(word) &&
+      !inappropriateWords.includes(word.toLowerCase())
+  );
+};


### PR DESCRIPTION
## Summary
- Ensure API-based suggestions are single, child-friendly words
- Filter spell-check suggestions against a banned word list
- Limit predictive word suggestions to single approved words

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4391e520083228d5680406e61cbdb