### PR TITLE
Add interactive spell checking to words

### DIFF
--- a/src/spellChecker.js
+++ b/src/spellChecker.js
@@ -21,11 +21,13 @@ export const initializeSpellChecker = () => {
 
 export const checkSpelling = (word) => {
   if (!spell) return true; // Assume correct if spell checker not initialized
-  return spell.correct(word);
+  const sanitized = word.toLowerCase().replace(/[^a-z']/g, '');
+  return spell.correct(sanitized);
 };
 
 export const getSuggestions = (word) => {
   if (!spell) return [];
-  const suggestions = spell.suggest(word);
+  const sanitized = word.toLowerCase().replace(/[^a-z']/g, '');
+  const suggestions = spell.suggest(sanitized);
   return filterChildFriendly(suggestions);
 };


### PR DESCRIPTION
## Summary
- initialize spell checker and track misspelled word suggestions
- show wavy red underline for misspelled words and clickable dropdown suggestions
- sanitize spell-check logic for safer dictionary lookups

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b47db2f0c883229e2dfd938ba15f69