### PR TITLE
Refine text entry and online TTS

### DIFF
--- a/src/components/SentenceBuilder.jsx
+++ b/src/components/SentenceBuilder.jsx
@@ -1,15 +1,7 @@
 // src/SentenceBuilder.jsx
 
 import { useState, useCallback, useEffect, Fragment } from 'react';
-import {
-  Save,
-  RefreshCw,
-  Eye,
-  Volume2,
-  VolumeX,
-  X,
-  Palette
-} from 'lucide-react';
+import { Save, Eye, Volume2, VolumeX, X, Palette } from 'lucide-react';
 
 import { themes } from './themes';
 import {
@@ -29,7 +21,7 @@ import { fetchWordClass, fetchSuggestions } from '../utils/dictionary';
 import { initializeSpellChecker, checkSpelling, getSuggestions } from '../spellChecker';
 
 // Import TTS functions and configurations
-import { speakText, initializeVoices } from './tts';
+import { speakText } from './tts';
 
 const SentenceBuilder = () => {
   /**
@@ -208,16 +200,7 @@ const SentenceBuilder = () => {
    * Text-to-Speech Initialization
    * ---------------------------
    */
-  useEffect(() => {
-    initializeVoices()
-      .then((voices) => {
-        console.log('Available voices:', voices);
-        // Optionally, set a default voice or handle voice selection here
-      })
-      .catch((error) => {
-        console.error('Error initializing voices:', error);
-      });
-  }, []);
+  // No voice initialization needed for online TTS
 
   /**
    * ---------------------------
@@ -414,32 +397,7 @@ const SentenceBuilder = () => {
     setSentences(newSentences);
   };
 
-  /**
-   * Randomizes the first 3 words in a sentence (determiner, adjective, noun)
-   * and ensures the last word has punctuation. If the sentence is empty,
-   * it will create a new set of 3 words.
-   */
-  const randomizeStartingPhrase = (sentenceIndex) => {
-    playSound('change');
-    const determiner =
-      vocabularyDB.determiners[
-        Math.floor(Math.random() * vocabularyDB.determiners.length)
-      ];
-    const adjective =
-      vocabularyDB.adjectives[
-        Math.floor(Math.random() * vocabularyDB.adjectives.length)
-      ];
-    const noun =
-      vocabularyDB.nouns[Math.floor(Math.random() * vocabularyDB.nouns.length)];
-
-    const newSentences = [...sentences];
-    newSentences[sentenceIndex].words = [
-      { word: determiner, type: 'determiner', punctuation: '' },
-      { word: adjective, type: 'adjective', punctuation: '' },
-      { word: noun, type: 'noun', punctuation: '.' }
-    ];
-    setSentences(newSentences);
-  };
+  // Removed shuffle functionality for cleaner experience
 
   /**
    * ---------------------------
@@ -773,14 +731,6 @@ const SentenceBuilder = () => {
                       className="bg-red-500 hover:bg-red-600"
                       size={24}
                     />
-                    <IconButton
-                      icon={RefreshCw}
-                      label="Randomize starting words"
-                      onClick={() => randomizeStartingPhrase(sentenceIndex)}
-                      className={`${theme.button} hover:rotate-180`}
-                      size={24}
-                    />
-
                     {/* New TTS Button */}
                     <IconButton
                       icon={Volume2}
@@ -831,21 +781,25 @@ const SentenceBuilder = () => {
          * =====================================
          */}
         {activeIndex !== null && activeSentenceIndex !== null && (
-          <ResizableDraggableModal
-            title="Choose a Word to Insert"
-            onClose={() => {
-              setActiveIndex(null);
-              setActiveSentenceIndex(null);
-              setHoveredWordIndex(null);
-              setCustomWord('');
-              setCustomWordType('unknown');
-            }}
-            theme={theme}
-            className="" // Removed width and height limiting classes
-          >
+          <div className="fixed bottom-0 left-0 w-full bg-white border-t border-gray-300 p-4 z-50 shadow-lg">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className={`font-semibold ${theme.primary}`}>Choose a Word to Insert</h2>
+              <button
+                onClick={() => {
+                  setActiveIndex(null);
+                  setActiveSentenceIndex(null);
+                  setHoveredWordIndex(null);
+                  setCustomWord('');
+                  setCustomWordType('unknown');
+                }}
+                aria-label="Close"
+              >
+                <X size={24} />
+              </button>
+            </div>
             <div className="flex flex-col lg:flex-row gap-4 lg:gap-8">
-              {/* 
-                PREVIEW of CURRENT SENTENCE 
+              {/*
+                PREVIEW of CURRENT SENTENCE
               */}
               <div className="flex-1 bg-gray-50 p-6 rounded-lg shadow-lg">
                 <h3
@@ -1074,7 +1028,7 @@ const SentenceBuilder = () => {
                 ))}
               </div>
             </div>
-          </ResizableDraggableModal>
+          </div>
         )}
 
         {/**
@@ -1083,21 +1037,25 @@ const SentenceBuilder = () => {
          * =====================================
          */}
         {showWordEditor && editingWord && (
-          <ResizableDraggableModal
-            title={
-              editingWord.mode === 'addPunctuation'
-                ? 'Add Punctuation'
-                : editingWord.mode === 'editPunctuation'
-                ? 'Edit Punctuation'
-                : 'Edit Word'
-            }
-            onClose={() => {
-              setShowWordEditor(false);
-              setEditingWord(null);
-            }}
-            theme={theme}
-            className="" // Removed width and height limiting classes
-          >
+          <div className="fixed bottom-0 left-0 w-full bg-white border-t border-gray-300 p-4 z-50 shadow-lg">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className={`font-semibold ${theme.primary}`}>
+                {editingWord.mode === 'addPunctuation'
+                  ? 'Add Punctuation'
+                  : editingWord.mode === 'editPunctuation'
+                  ? 'Edit Punctuation'
+                  : 'Edit Word'}
+              </h2>
+              <button
+                onClick={() => {
+                  setShowWordEditor(false);
+                  setEditingWord(null);
+                }}
+                aria-label="Close"
+              >
+                <X size={24} />
+              </button>
+            </div>
             {editingWord.mode === 'addPunctuation' ||
             editingWord.mode === 'editPunctuation' ? (
               <PunctuationEditor
@@ -1126,7 +1084,7 @@ const SentenceBuilder = () => {
                 theme={theme}
               />
             )}
-          </ResizableDraggableModal>
+          </div>
         )}
 
         {/**

--- a/src/components/tts.js
+++ b/src/components/tts.js
@@ -1,99 +1,16 @@
-// src/tts.js
+// src/components/tts.js
 
 /**
- * Text-to-Speech (TTS) Module
- * 
- * This module provides functions to handle Text-to-Speech functionalities using the Web Speech API.
- * 
- * Configurable Variables:
- * - rate: Speed at which the text is spoken. Range: 0.1 to 10 (default: 1)
- * - pitch: Pitch of the voice. Range: 0 to 2 (default: 1)
- * - volume: Volume of the speech. Range: 0 to 1 (default: 1)
- * - voiceURI: The URI of the voice to use. If not specified, the default voice is used.
- */
-
-let selectedVoice = null;
-
-// Configurable Variables
-export const ttsConfig = {
-  rate: 0.5,        // Speech rate (0.1 to 10)
-  pitch: 1.8,     // Speech pitch (0 to 2) - Increased pitch for child-friendly voice
-  volume: 1,      // Speech volume (0 to 1)
-  voiceURI: 'Google UK English Female', // Default to Google UK English Female
-};
-
-/**
- * Initialize and set the selected voice based on the voiceURI.
- * This should be called once after the component mounts to populate available voices.
- */
-export const initializeVoices = () => {
-  return new Promise((resolve, reject) => {
-    const synth = window.speechSynthesis;
-
-    if (!synth) {
-      reject(new Error('Speech Synthesis not supported in this browser.'));
-      return;
-    }
-
-    const loadVoices = () => {
-      const voices = synth.getVoices();
-      if (ttsConfig.voiceURI) {
-        selectedVoice = voices.find(voice => voice.name === ttsConfig.voiceURI) || null;
-      } else {
-        selectedVoice = voices.find(voice => voice.lang === 'en-US') || null; // Default to first English voice
-      }
-      resolve(voices);
-    };
-
-    if (synth.onvoiceschanged !== undefined) {
-      synth.onvoiceschanged = loadVoices;
-    } else {
-      loadVoices();
-    }
-  });
-};
-
-/**
- * Speak the given text using the Web Speech API.
- * @param {string} text - The text to be spoken.
+ * Simple Text-to-Speech helper that uses an online service.
+ * The function constructs a Google Translate TTS URL and plays it.
+ * This requires an active internet connection.
  */
 export const speakText = (text) => {
-  if (!('speechSynthesis' in window)) {
-    alert('Sorry, your browser does not support Text-to-Speech.');
-    return;
-  }
-
-  const synth = window.speechSynthesis;
-  synth.cancel(); // Cancel any ongoing speech
-
-  const utterance = new SpeechSynthesisUtterance(text);
-  
-  // Apply configurations
-  utterance.rate = ttsConfig.rate;
-  utterance.pitch = ttsConfig.pitch;
-  utterance.volume = ttsConfig.volume;
-  
-  if (selectedVoice) {
-    utterance.voice = selectedVoice;
-  }
-
-  synth.speak(utterance);
-};
-
-/**
- * Set the voice based on voice name.
- * @param {string} voiceName - The name of the desired voice.
- */
-export const setVoice = (voiceName) => {
-  const synth = window.speechSynthesis;
-  const voices = synth.getVoices();
-  selectedVoice = voices.find(voice => voice.name === voiceName) || null;
-};
-
-/**
- * Get all available voices.
- * @returns {SpeechSynthesisVoice[]} - Array of available voices.
- */
-export const getAvailableVoices = () => {
-  return window.speechSynthesis.getVoices();
+  if (!text) return;
+  const encoded = encodeURIComponent(text);
+  const url = `https://translate.googleapis.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=${encoded}`;
+  const audio = new Audio(url);
+  audio.play().catch((err) => {
+    console.error('Failed to play TTS audio', err);
+  });
 };


### PR DESCRIPTION
## Summary
- drop shuffle/randomize controls for a cleaner workflow
- use online Google TTS endpoint for audio playback
- embed word and punctuation editors in bottom panels instead of popup windows

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b48250c14c8322b8d9557316020a09