### PR TITLE
Add word mat and browser-based text-to-speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # sentence-builder
+
+## Features
+
+- Words are coloured based on their part of speech.
+- Built-in text-to-speech using the browser's SpeechSynthesis API.
+- A bottom word mat groups vocabulary by type; toggle it with the palette button.

--- a/src/components/SentenceBuilder.jsx
+++ b/src/components/SentenceBuilder.jsx
@@ -1,10 +1,11 @@
 // src/SentenceBuilder.jsx
 
-import { useState, useCallback, useEffect, Fragment } from 'react';
+import { useState, useCallback, useEffect, Fragment, useMemo } from 'react';
 import { Save, Eye, Volume2, VolumeX, X, Palette } from 'lucide-react';
 
 import { themes } from './themes';
 import { csvToVocabCategory, wordClassColours } from './mappings';
+import WordMat from './WordMat';
 import IconButton from './IconButton';
 import ResizableDraggableModal from './ResizableDraggableModal'; // Ensure correct import path
 import WordContextMenu from './WordContextMenu';
@@ -77,6 +78,17 @@ const SentenceBuilder = () => {
   });
 
   const [typingPosition, setTypingPosition] = useState(null);
+  const [showWordMat, setShowWordMat] = useState(false);
+
+  const mergedVocabulary = useMemo(() => {
+    const combined = {};
+    Object.keys(vocabularyDB).forEach((key) => {
+      combined[key] = Array.from(
+        new Set([...(vocabularyDB[key] || []), ...(wordieDB[key] || [])])
+      );
+    });
+    return combined;
+  }, [vocabularyDB, wordieDB]);
 
   const theme = themes[currentTheme];
 
@@ -705,21 +717,36 @@ const SentenceBuilder = () => {
           {/*
             SAVE BUTTON
           */}
-          {sentences.length > 0 && (
-            <div className="flex justify-center">
-              <button
-                onClick={saveSentencesAsTextFile}
-                className={`flex items-center gap-2 sm:gap-4 px-6 sm:px-12 py-4 sm:py-6 ${theme.button} text-white rounded-xl font-semibold transition-all duration-300 hover:scale-105 focus:outline-none focus:ring-4 focus:ring-green-300 text-base sm:text-lg md:text-2xl`}
-              >
-                <Save size={24} className="sm:hidden" />
-                <Save size={32} className="hidden sm:inline" />
-                <span className="hidden sm:inline">Save My Story</span>
-              </button>
-            </div>
-          )}
-        </main>
+        {sentences.length > 0 && (
+          <div className="flex justify-center">
+            <button
+              onClick={saveSentencesAsTextFile}
+              className={`flex items-center gap-2 sm:gap-4 px-6 sm:px-12 py-4 sm:py-6 ${theme.button} text-white rounded-xl font-semibold transition-all duration-300 hover:scale-105 focus:outline-none focus:ring-4 focus:ring-green-300 text-base sm:text-lg md:text-2xl`}
+            >
+              <Save size={24} className="sm:hidden" />
+              <Save size={32} className="hidden sm:inline" />
+              <span className="hidden sm:inline">Save My Story</span>
+            </button>
+          </div>
+        )}
+      </main>
 
-        {/* Inline word input is rendered directly in the sentence; modal removed */}
+      <IconButton
+        icon={Palette}
+        label={showWordMat ? 'Hide word mat' : 'Show word mat'}
+        onClick={() => setShowWordMat(!showWordMat)}
+        className="fixed bottom-4 right-4 bg-blue-500 hover:bg-blue-600"
+        size={24}
+      />
+
+      <WordMat
+        open={showWordMat}
+        onClose={() => setShowWordMat(false)}
+        vocabulary={mergedVocabulary}
+        onWordClick={(word) => insertWord(word)}
+      />
+
+      {/* Inline word input is rendered directly in the sentence; modal removed */}
 
         {/**
          * =====================================

--- a/src/components/WordMat.jsx
+++ b/src/components/WordMat.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import { wordClassBackgroundColours } from './mappings';
+
+/**
+ * A sliding panel that displays words grouped by their type.
+ * Initially hidden and appears from the bottom when opened.
+ */
+const WordMat = ({ open, onClose, vocabulary, onWordClick }) => {
+  const categories = Object.keys(vocabulary);
+
+  return (
+    <div
+      className={`fixed bottom-0 left-0 right-0 bg-white shadow-lg transform transition-transform duration-300 z-40 ${
+        open ? 'translate-y-0' : 'translate-y-full'
+      }`}
+    >
+      <div className="flex justify-between items-center p-4 border-b">
+        <h2 className="font-semibold">Word Mat</h2>
+        <button onClick={onClose} className="text-xl" aria-label="Close word mat">
+          &times;
+        </button>
+      </div>
+      <div className="p-4 max-h-60 overflow-y-auto">
+        {categories.map((cat) => (
+          <div key={cat} className="mb-4">
+            <h3 className="capitalize font-semibold mb-2">{cat}</h3>
+            <div className="flex flex-wrap gap-2">
+              {vocabulary[cat].map((word, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => onWordClick(word)}
+                  className={`text-white px-2 py-1 rounded ${
+                    wordClassBackgroundColours[cat.slice(0, -1)] || 'bg-gray-300'
+                  }`}
+                >
+                  {word}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+WordMat.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  vocabulary: PropTypes.object.isRequired,
+  onWordClick: PropTypes.func.isRequired,
+};
+
+export default WordMat;

--- a/src/components/tts.js
+++ b/src/components/tts.js
@@ -1,16 +1,19 @@
 // src/components/tts.js
 
 /**
- * Simple Text-to-Speech helper that uses an online service.
- * The function constructs a Google Translate TTS URL and plays it.
- * This requires an active internet connection.
+ * Simple Text-to-Speech helper.
+ * Uses the browser's SpeechSynthesis API when available.
+ * Falls back to logging a warning if the API is unsupported.
  */
 export const speakText = (text) => {
   if (!text) return;
-  const encoded = encodeURIComponent(text);
-  const url = `https://translate.googleapis.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en&q=${encoded}`;
-  const audio = new Audio(url);
-  audio.play().catch((err) => {
-    console.error('Failed to play TTS audio', err);
-  });
+
+  if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+    const utterance = new SpeechSynthesisUtterance(text);
+    // Cancel any ongoing speech to avoid overlaps
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utterance);
+  } else {
+    console.warn('SpeechSynthesis API is not supported in this browser');
+  }
 };


### PR DESCRIPTION
## Summary
- Add sliding word mat showing vocabulary grouped by part of speech
- Replace Google Translate audio hack with SpeechSynthesis API
- Document features including colour-coded words and word mat toggle

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "compromise" from src/utils/dictionary.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b48a75a78483228c99f90bb2aad9b9