### PR TITLE
feat: add Netlify gptNano function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 - Words are coloured based on their part of speech.
 - Built-in text-to-speech using the browser's SpeechSynthesis API.
 - A bottom word mat groups vocabulary by type; toggle it with the palette button.
+
+## Environment variables
+
+Set `OPENAI_API_KEY` in your Netlify project settings. The key is read by the Netlify function and is not exposed to the client.

--- a/netlify/functions/gptNano.js
+++ b/netlify/functions/gptNano.js
@@ -1,0 +1,43 @@
+/* eslint-env node */
+
+import process from 'node:process';
+
+export async function handler(event) {
+  const { sentence } = JSON.parse(event.body || '{}');
+  const prompt = `You are a helpful writing assistant for children. Given the sentence fragment below, suggest improvements and the next word.
+Return suggestions using the commands:
+
+[SPELLING]: WORD INDEX
+[IMPROVE]: WORD INDEX -> [IMPROVE_TO]: {NEW_WORD}
+[ADDINNEWWORD]: {NEW_WORD} [AFTER]: WORD INDEX
+
+Only include commands that apply.
+
+Sentence: "${sentence}"`;
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        input: prompt,
+        max_output_tokens: 150
+      })
+    });
+    const data = await res.json();
+    return {
+      statusCode: res.status,
+      body: JSON.stringify(data)
+    };
+  } catch (err) {
+    console.error('Nano feedback failed', err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Nano feedback failed' })
+    };
+  }
+}

--- a/src/utils/gptNano.js
+++ b/src/utils/gptNano.js
@@ -1,27 +1,11 @@
 export const getNanoFeedback = async (sentence) => {
-  const prompt = `You are a helpful writing assistant for children. Given the sentence fragment below, suggest improvements and the next word.
-Return suggestions using the commands:
-
-[SPELLING]: WORD INDEX
-[IMPROVE]: WORD INDEX -> [IMPROVE_TO]: {NEW_WORD}
-[ADDINNEWWORD]: {NEW_WORD} [AFTER]: WORD INDEX
-
-Only include commands that apply.
-
-Sentence: "${sentence}"`;
-
   try {
-    const res = await fetch('https://api.openai.com/v1/responses', {
+    const res = await fetch('/.netlify/functions/gptNano', {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
+        'Content-Type': 'application/json'
       },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        input: prompt,
-        max_output_tokens: 150
-      })
+      body: JSON.stringify({ sentence })
     });
     const data = await res.json();
     return data?.output_text || '';


### PR DESCRIPTION
## Summary
- add Netlify serverless function to proxy gptNano requests to OpenAI using `OPENAI_API_KEY`
- update client util to call Netlify endpoint instead of OpenAI directly
- document `OPENAI_API_KEY` configuration in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b48f5642d483229ad03f24047b8439