### PR TITLE
Refactor app into EAL-focused Docs workspace

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,21 +1,544 @@
-/* Reset any default styles */
-#root {
+:root {
+  --docs-blue: #1a73e8;
+  --docs-surface: #f1f3f4;
+  --docs-text: #202124;
+  --docs-muted: #5f6368;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: var(--docs-surface);
+  color: var(--docs-text);
+  display: flex;
+  flex-direction: column;
+  font-family: 'Inter', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.docs-top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.8rem;
+  background: var(--docs-blue);
+  color: #fff;
+  box-shadow: 0 3px 12px rgba(26, 115, 232, 0.35);
+}
+
+.top-left {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.docs-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.docs-title {
+  border: none;
+  background: transparent;
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+  width: 220px;
+  transition: background 0.2s ease;
+}
+
+.docs-title:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.assist-button,
+.share-button {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.assist-button {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  padding: 0.35rem 0.9rem;
+}
+
+.assist-button:hover {
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
+  transform: translateY(-1px);
+}
+
+.share-button {
+  border: none;
+  background: #0b57d0;
+  color: #fff;
+  padding: 0.45rem 1.2rem;
+  box-shadow: 0 4px 12px rgba(0, 87, 208, 0.35);
+}
+
+.share-button:hover {
+  box-shadow: 0 5px 14px rgba(0, 87, 208, 0.4);
+  transform: translateY(-1px);
+}
+
+.docs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1.8rem;
+  background: #f8f9fa;
+  border-bottom: 1px solid #dfe1e5;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toolbar-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid #dadce0;
+  background: #fff;
+  color: #3c4043;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.toolbar-button:hover {
+  background: #e8f0fe;
+  border-color: var(--docs-blue);
+  transform: translateY(-1px);
+}
+
+.toolbar-button i {
+  font-style: italic;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.outline-panel {
+  width: 240px;
+  border-right: 1px solid #e0e3eb;
+  background: #f8f9fa;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1rem;
+}
+
+.outline-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1f1f1f;
+}
+
+.outline-content {
+  flex: 1;
+  overflow: auto;
+  padding-right: 0.5rem;
+}
+
+.outline-content ol {
   margin: 0;
-  padding: 0;
-  width: 100%;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-size: 0.9rem;
 }
 
-/* Custom styles for interactive elements */
-select {
-  appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right 0.5rem center;
-  background-size: 1em;
-  padding-right: 2.5rem;
+.outline-content li {
+  color: var(--docs-muted);
 }
 
-/* Smooth transitions for theme changes */
-* {
-  transition: background-color 0.3s ease, color 0.3s ease;
+.outline-empty {
+  font-size: 0.85rem;
+  color: var(--docs-muted);
+  line-height: 1.5;
+}
+
+.outline-footer {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--docs-muted);
+  padding: 0.75rem;
+  background: #eef2ff;
+  border-radius: 10px;
+}
+
+.document-area {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 2.25rem 0;
+  overflow: auto;
+}
+
+.document-page {
+  width: 760px;
+  min-height: calc(100vh - 200px);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 18px 45px rgba(60, 64, 67, 0.2);
+  padding: 72px 88px 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: relative;
+}
+
+.doc-editor {
+  flex: 1;
+  min-height: 620px;
+  border: none;
+  resize: none;
+  outline: none;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--docs-text);
+  font-family: 'Inter', 'Noto Sans', 'Calibri', sans-serif;
+  background: transparent;
+}
+
+.doc-editor::placeholder {
+  color: #bdc1c6;
+}
+
+.doc-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.status-chip {
+  background: #f1f3ff;
+  border: 1px solid #d7dcff;
+  border-radius: 10px;
+  padding: 0.45rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  min-width: 110px;
+}
+
+.status-label {
+  font-size: 0.75rem;
+  color: #5f6368;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.status-value {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #1f1f1f;
+}
+
+.support-message {
+  background: #e8f0fe;
+  color: var(--docs-blue);
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.15);
+}
+
+.support-rail {
+  width: 320px;
+  border-left: 1px solid #e0e3eb;
+  background: #f8f9fb;
+  padding: 1.6rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  overflow-y: auto;
+}
+
+.panel-section {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(60, 64, 67, 0.16);
+  padding: 1.2rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.section-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f1f1f;
+}
+
+.section-header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--docs-muted);
+}
+
+.word-bank-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.word-bank-tab {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: #eef1fb;
+  color: #1f1f1f;
+  padding: 0.35rem 0.85rem 0.35rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease, color 0.18s ease;
+}
+
+.word-bank-tab.active {
+  background: var(--docs-blue);
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(26, 115, 232, 0.25);
+}
+
+.word-bank-tab:hover {
+  transform: translateY(-1px);
+}
+
+.tab-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.word-bank-grid {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.word-bank-chip {
+  border: 1px solid #dfe1e5;
+  border-radius: 12px;
+  background: #f6f8fe;
+  padding: 0.65rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.word-bank-chip:hover {
+  border-color: var(--docs-blue);
+  box-shadow: 0 6px 20px rgba(26, 115, 232, 0.12);
+}
+
+.chip-emoji {
+  font-size: 1.1rem;
+}
+
+.chip-text {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f1f1f;
+}
+
+.chip-hint {
+  font-size: 0.75rem;
+  color: var(--docs-muted);
+}
+
+.prediction-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.prediction-card {
+  border: 1px solid #dfe1e5;
+  border-radius: 12px;
+  background: #fff;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.prediction-card:hover {
+  border-color: var(--docs-blue);
+  box-shadow: 0 6px 18px rgba(26, 115, 232, 0.18);
+}
+
+.prediction-text {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f1f1f;
+}
+
+.prediction-meta {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--docs-muted);
+}
+
+.prediction-hint {
+  font-size: 0.78rem;
+  color: #3c4043;
+}
+
+.frames-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.frame-card {
+  background: #f4f6ff;
+  border: 1px solid #d2d7ff;
+  border-radius: 12px;
+  padding: 0.9rem;
+}
+
+.frame-card h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1f1f1f;
+}
+
+.frame-text {
+  margin: 0.4rem 0;
+  font-weight: 600;
+  color: #1a73e8;
+}
+
+.frame-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--docs-muted);
+}
+
+.focus-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  font-size: 0.88rem;
+  color: #1f1f1f;
+}
+
+.focus-list li {
+  line-height: 1.5;
+}
+
+.used-words {
+  margin-top: 1rem;
+}
+
+.used-words h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: #1f1f1f;
+}
+
+.used-words-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.used-word {
+  background: #e6f4ea;
+  color: #0b8043;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+@media (max-width: 1200px) {
+  .workspace {
+    flex-direction: column;
+  }
+
+  .outline-panel,
+  .support-rail {
+    width: 100%;
+    border: none;
+    order: -1;
+  }
+
+  .document-area {
+    padding: 1.5rem 0.75rem 4rem;
+  }
+
+  .support-rail {
+    padding: 1rem;
+  }
+
+  .document-page {
+    width: 100%;
+    padding: 56px 48px 96px;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-toolbar {
+    justify-content: center;
+  }
+
+  .document-page {
+    padding: 48px 24px 72px;
+  }
+
+  .doc-editor {
+    min-height: 420px;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,521 @@
-import SentenceBuilder from './components/SentenceBuilder';
+import { useMemo, useRef, useState } from 'react';
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  Bold,
+  BookOpen,
+  Highlighter,
+  Languages,
+  Lightbulb,
+  List,
+  PenSquare,
+  Share,
+  Sparkles,
+  Underline,
+  Wand2
+} from 'lucide-react';
 import './App.css';
+import {
+  focusQuestions,
+  languageFrames,
+  nextWordMap,
+  phraseContinuations,
+  wordBank
+} from './data/ealContent';
+
+const defaultFocus = {
+  currentWord: '',
+  previousWord: '',
+  currentSentence: '',
+  precedingText: ''
+};
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 function App() {
+  const [documentTitle, setDocumentTitle] = useState('Untitled document');
+  const [documentText, setDocumentText] = useState('');
+  const [activeCategory, setActiveCategory] = useState(wordBank[0].id);
+  const [focusState, setFocusState] = useState(defaultFocus);
+  const editorRef = useRef(null);
+
+  const activeWordBank = useMemo(
+    () => wordBank.find((category) => category.id === activeCategory) ?? wordBank[0],
+    [activeCategory]
+  );
+
+  const allWordOptions = useMemo(() => {
+    const words = new Set();
+    wordBank.forEach((category) => {
+      category.entries.forEach((entry) => {
+        entry.text
+          .split(/\s+/)
+          .filter(Boolean)
+          .forEach((word) => words.add(word.toLowerCase()));
+      });
+    });
+    return Array.from(words);
+  }, []);
+
+  const connectorWords = useMemo(() => {
+    const connectorCategory = wordBank.find((category) => category.id === 'connectors');
+    return connectorCategory ? connectorCategory.entries.map((entry) => entry.text) : [];
+  }, []);
+
+  const wordCount = useMemo(() => {
+    const words = documentText.trim().match(/\b[\w']+\b/g);
+    return words ? words.length : 0;
+  }, [documentText]);
+
+  const sentenceCount = useMemo(() => {
+    const sentences = documentText.split(/[.!?]+/).map((sentence) => sentence.trim());
+    return sentences.filter(Boolean).length;
+  }, [documentText]);
+
+  const connectorsUsed = useMemo(() => {
+    const lowerText = documentText.toLowerCase();
+    return connectorWords.filter((connector) => {
+      const pattern = new RegExp(`\\b${escapeRegExp(connector.toLowerCase())}\\b`);
+      return pattern.test(lowerText);
+    });
+  }, [connectorWords, documentText]);
+
+  const estimatedReadingTime = useMemo(() => {
+    if (wordCount === 0) return 0;
+    return Math.max(1, Math.round(wordCount / 80));
+  }, [wordCount]);
+
+  const outline = useMemo(() => {
+    return documentText
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(0, 5);
+  }, [documentText]);
+
+  const usedVocabulary = useMemo(() => {
+    const matches = new Set();
+    const lower = documentText.toLowerCase();
+    wordBank.forEach((category) => {
+      category.entries.forEach((entry) => {
+        if (entry.text.includes(' ')) return;
+        const pattern = new RegExp(`\\b${escapeRegExp(entry.text.toLowerCase())}\\b`);
+        if (pattern.test(lower)) {
+          matches.add(entry.text);
+        }
+      });
+    });
+    return Array.from(matches).sort();
+  }, [documentText]);
+
+  const supportMessage = useMemo(() => {
+    if (wordCount < 10) {
+      return 'Try to write one full sentence about your idea.';
+    }
+    if (sentenceCount < 2) {
+      return 'Can you add another sentence to explain more?';
+    }
+    if (connectorsUsed.length === 0) {
+      return 'Add a connector like "because" or "then" to join your ideas.';
+    }
+    return 'Great! Now check if your sentences have feelings, actions and reasons.';
+  }, [wordCount, sentenceCount, connectorsUsed.length]);
+
+  const updateCaretMetadata = () => {
+    const textarea = editorRef.current;
+    if (!textarea) return;
+
+    const cursorIndex = textarea.selectionStart;
+    const textBefore = textarea.value.slice(0, cursorIndex);
+    const trailingSpace = /\s$/.test(textBefore);
+    const tokens = textBefore.split(/\s+/).filter(Boolean);
+
+    const currentWord = trailingSpace ? '' : tokens[tokens.length - 1] || '';
+    const previousWord = trailingSpace
+      ? tokens[tokens.length - 1] || ''
+      : tokens[tokens.length - 2] || '';
+
+    const sentences = textBefore
+      .split(/[.!?]/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+
+    setFocusState({
+      currentWord,
+      previousWord,
+      currentSentence: sentences[sentences.length - 1] || '',
+      precedingText: textBefore
+    });
+  };
+
+  const handleEditorChange = (event) => {
+    setDocumentText(event.target.value);
+    requestAnimationFrame(updateCaretMetadata);
+  };
+
+  const handleSelectionUpdate = () => {
+    requestAnimationFrame(updateCaretMetadata);
+  };
+
+  const applySuggestion = (suggestion) => {
+    if (!editorRef.current || !suggestion?.text) return;
+
+    const textarea = editorRef.current;
+    const { replaceCurrent = true, appendSpace = true, prependSpace = false } = suggestion;
+    let start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+
+    if (replaceCurrent && focusState.currentWord) {
+      start = Math.max(0, start - focusState.currentWord.length);
+    }
+
+    const before = documentText.slice(0, start);
+    const after = documentText.slice(end);
+    const isSentenceStart = !before || /[.!?\n]\s*$/.test(before);
+
+    let insertText = suggestion.text;
+    if (suggestion.autoCapitalize !== false && insertText.length) {
+      if (isSentenceStart) {
+        insertText = insertText.charAt(0).toUpperCase() + insertText.slice(1);
+      }
+    }
+
+    if (suggestion.forceLowercase && insertText.length) {
+      insertText = insertText.charAt(0).toLowerCase() + insertText.slice(1);
+    }
+
+    const needsLeadingSpace = prependSpace && before && !/\s$/.test(before);
+    const needsTrailingSpace = appendSpace;
+
+    const finalText = `${needsLeadingSpace ? ' ' : ''}${insertText}${needsTrailingSpace ? ' ' : ''}`;
+    const newValue = `${before}${finalText}${after}`;
+    const newCursor = before.length + finalText.length;
+
+    setDocumentText(newValue);
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.selectionStart = newCursor;
+      textarea.selectionEnd = newCursor;
+      updateCaretMetadata();
+    });
+  };
+
+  const insertFromWordBank = (entry) => {
+    applySuggestion({ ...entry, source: 'Word bank' });
+  };
+
+  const predictions = useMemo(() => {
+    const suggestions = new Map();
+    const prefix = (focusState.currentWord || '').toLowerCase();
+    const previous = (focusState.previousWord || '').toLowerCase();
+    const context = (focusState.precedingText || '').trimEnd().toLowerCase();
+
+    if (prefix) {
+      allWordOptions
+        .filter((word) => word.startsWith(prefix) && word !== prefix)
+        .slice(0, 4)
+        .forEach((word) => {
+          const key = `prefix-${word}`;
+          if (!suggestions.has(key)) {
+            suggestions.set(key, {
+              id: key,
+              text: word,
+              source: 'Word match',
+              hint: 'Complete the word from the bank.',
+              appendSpace: true,
+              replaceCurrent: true
+            });
+          }
+        });
+    }
+
+    if (!prefix && previous) {
+      (nextWordMap[previous] || []).forEach((word) => {
+        const key = `next-${previous}-${word}`;
+        if (!suggestions.has(key)) {
+          suggestions.set(key, {
+            id: key,
+            text: word,
+            source: 'Next word idea',
+            hint: `Add "${word}" to grow the sentence.`,
+            appendSpace: true,
+            prependSpace: true,
+            replaceCurrent: false,
+            autoCapitalize: false
+          });
+        }
+      });
+    }
+
+    phraseContinuations.forEach((rule) => {
+      if (rule.pattern.test(context)) {
+        rule.suggestions.forEach((item, index) => {
+          const key = `phrase-${rule.id}-${index}-${item.text.toLowerCase()}`;
+          if (!suggestions.has(key)) {
+            suggestions.set(key, {
+              id: key,
+              text: item.text,
+              source: rule.label,
+              hint: item.hint,
+              appendSpace: item.appendSpace ?? true,
+              prependSpace: item.prependSpace ?? false,
+              replaceCurrent: item.replaceCurrent ?? true,
+              autoCapitalize: item.autoCapitalize ?? false
+            });
+          }
+        });
+      }
+    });
+
+    if (suggestions.size === 0) {
+      ['I feel', 'We can', 'because'].forEach((phrase, index) => {
+        const key = `starter-${index}`;
+        suggestions.set(key, {
+          id: key,
+          text: phrase,
+          source: 'Try this starter',
+          hint: 'Use this phrase to begin a new idea.',
+          appendSpace: true,
+          replaceCurrent: true
+        });
+      });
+    }
+
+    return Array.from(suggestions.values()).slice(0, 6);
+  }, [allWordOptions, focusState]);
+
+  const statusHighlights = [
+    { label: 'Word count', value: wordCount },
+    { label: 'Sentences', value: sentenceCount },
+    { label: 'Connectors used', value: connectorsUsed.length },
+    { label: 'Reading time', value: estimatedReadingTime ? `${estimatedReadingTime} min` : '—' }
+  ];
+
   return (
-    <div className="min-h-screen bg-white">
-      <main className="h-screen">
-        <SentenceBuilder />
-      </main>
+    <div className="app-shell">
+      <header className="docs-top-bar">
+        <div className="top-left">
+          <div className="docs-logo">
+            <BookOpen size={22} />
+            <span>EAL Docs</span>
+          </div>
+          <input
+            className="docs-title"
+            value={documentTitle}
+            onChange={(event) => setDocumentTitle(event.target.value)}
+            aria-label="Document title"
+          />
+        </div>
+        <div className="top-actions">
+          <button className="assist-button" type="button">
+            <Languages size={16} />
+            Language help
+          </button>
+          <button className="share-button" type="button">
+            <Share size={16} />
+            Share
+          </button>
+        </div>
+      </header>
+
+      <div className="docs-toolbar">
+        <div className="toolbar-group">
+          <button type="button" className="toolbar-button" aria-label="Bold">
+            <Bold size={16} />
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Italic">
+            <i>I</i>
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Underline">
+            <Underline size={16} />
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Highlight">
+            <Highlighter size={16} />
+          </button>
+        </div>
+        <div className="toolbar-group">
+          <button type="button" className="toolbar-button" aria-label="Align left">
+            <AlignLeft size={16} />
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Align centre">
+            <AlignCenter size={16} />
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Align right">
+            <AlignRight size={16} />
+          </button>
+        </div>
+        <div className="toolbar-group">
+          <button type="button" className="toolbar-button" aria-label="Paragraph outline">
+            <List size={16} />
+          </button>
+          <button type="button" className="toolbar-button" aria-label="Writing goals">
+            <PenSquare size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className="workspace">
+        <aside className="outline-panel">
+          <div className="outline-header">
+            <List size={16} />
+            <span>Outline</span>
+          </div>
+          <div className="outline-content">
+            {outline.length === 0 ? (
+              <p className="outline-empty">
+                Your headings will appear here. Try turning your first sentence into a heading!
+              </p>
+            ) : (
+              <ol>
+                {outline.map((line, index) => (
+                  <li key={line + index}>{line}</li>
+                ))}
+              </ol>
+            )}
+          </div>
+          <div className="outline-footer">
+            <Lightbulb size={16} />
+            <span>Need an idea? Choose a focus question from the right panel.</span>
+          </div>
+        </aside>
+
+        <main className="document-area">
+          <div className="document-page">
+            <textarea
+              ref={editorRef}
+              className="doc-editor"
+              value={documentText}
+              onChange={handleEditorChange}
+              onClick={handleSelectionUpdate}
+              onKeyUp={handleSelectionUpdate}
+              onSelect={handleSelectionUpdate}
+              placeholder="Start writing about your learning..."
+              spellCheck
+            />
+            <div className="doc-status">
+              {statusHighlights.map((item) => (
+                <div key={item.label} className="status-chip">
+                  <span className="status-label">{item.label}</span>
+                  <span className="status-value">{item.value}</span>
+                </div>
+              ))}
+            </div>
+            <div className="support-message">{supportMessage}</div>
+          </div>
+        </main>
+
+        <aside className="support-rail">
+          <section className="panel-section">
+            <div className="section-header">
+              <Sparkles size={18} />
+              <div>
+                <h3>Word bank</h3>
+                <p>Tap a word or phrase to add it to your writing.</p>
+              </div>
+            </div>
+            <div className="word-bank-tabs">
+              {wordBank.map((category) => (
+                <button
+                  key={category.id}
+                  type="button"
+                  className={`word-bank-tab ${category.id === activeCategory ? 'active' : ''}`}
+                  onClick={() => setActiveCategory(category.id)}
+                >
+                  <span className="tab-indicator" style={{ backgroundColor: category.color }} />
+                  {category.label}
+                </button>
+              ))}
+            </div>
+            <div className="word-bank-grid">
+              {activeWordBank.entries.map((entry) => (
+                <button
+                  key={entry.text}
+                  type="button"
+                  className="word-bank-chip"
+                  onClick={() => insertFromWordBank(entry)}
+                >
+                  <span className="chip-emoji" aria-hidden>
+                    {entry.emoji}
+                  </span>
+                  <span className="chip-text">{entry.text}</span>
+                  <span className="chip-hint">{entry.hint}</span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="panel-section">
+            <div className="section-header">
+              <Wand2 size={18} />
+              <div>
+                <h3>Smart predictions</h3>
+                <p>Finish your sentence with a quick suggestion.</p>
+              </div>
+            </div>
+            <div className="prediction-grid">
+              {predictions.map((suggestion) => (
+                <button
+                  key={suggestion.id}
+                  type="button"
+                  className="prediction-card"
+                  onClick={() => applySuggestion(suggestion)}
+                >
+                  <span className="prediction-text">{suggestion.text}</span>
+                  <span className="prediction-meta">{suggestion.source}</span>
+                  {suggestion.hint && <span className="prediction-hint">{suggestion.hint}</span>}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="panel-section">
+            <div className="section-header">
+              <PenSquare size={18} />
+              <div>
+                <h3>Language frames</h3>
+                <p>Use a frame to organise your thinking.</p>
+              </div>
+            </div>
+            <div className="frames-grid">
+              {languageFrames.map((frame) => (
+                <div key={frame.title} className="frame-card">
+                  <h4>{frame.title}</h4>
+                  <p className="frame-text">{frame.frame}</p>
+                  <p className="frame-hint">{frame.description}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="panel-section">
+            <div className="section-header">
+              <Lightbulb size={18} />
+              <div>
+                <h3>Focus questions</h3>
+                <p>Pick one to add more detail.</p>
+              </div>
+            </div>
+            <ul className="focus-list">
+              {focusQuestions.map((question) => (
+                <li key={question}>{question}</li>
+              ))}
+            </ul>
+            {usedVocabulary.length > 0 && (
+              <div className="used-words">
+                <h4>Words you used</h4>
+                <div className="used-words-grid">
+                  {usedVocabulary.map((word) => (
+                    <span key={word} className="used-word">
+                      {word}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/data/ealContent.js
+++ b/src/data/ealContent.js
@@ -1,0 +1,263 @@
+export const wordBank = [
+  {
+    id: 'starters',
+    label: 'Sentence starters',
+    color: '#1a73e8',
+    entries: [
+      { text: 'I feel', hint: 'Share a feeling to begin your idea.', emoji: '💬' },
+      { text: 'I can', hint: 'Talk about something you are able to do.', emoji: '💪' },
+      { text: 'Today I', hint: 'Explain what is happening today.', emoji: '📅' },
+      { text: 'When I', hint: 'Describe what happens in a moment.', emoji: '⏰' },
+      { text: 'My friend and I', hint: 'Write about working together.', emoji: '🤝', replaceCurrent: false },
+      { text: 'In my classroom', hint: 'Describe your learning space.', emoji: '🏫', replaceCurrent: false }
+    ]
+  },
+  {
+    id: 'feelings',
+    label: 'Feelings & people',
+    color: '#fbbc04',
+    entries: [
+      { text: 'happy', hint: 'Feeling good or joyful.', emoji: '😊' },
+      { text: 'worried', hint: 'Feeling a little unsure.', emoji: '😟', autoCapitalize: false },
+      { text: 'excited', hint: 'Feeling very interested.', emoji: '🤩', autoCapitalize: false },
+      { text: 'proud', hint: 'Feeling good about what you did.', emoji: '🌟', autoCapitalize: false },
+      { text: 'teacher', hint: 'A grown-up who helps you learn.', emoji: '👩‍🏫', autoCapitalize: false },
+      { text: 'classmates', hint: 'Friends learning with you.', emoji: '🧑‍🤝‍🧑', autoCapitalize: false }
+    ]
+  },
+  {
+    id: 'actions',
+    label: 'Action words',
+    color: '#34a853',
+    entries: [
+      { text: 'explore', hint: 'Find out more about something.', emoji: '🔍', autoCapitalize: false },
+      { text: 'build', hint: 'Make or create something.', emoji: '🧱', autoCapitalize: false },
+      { text: 'share', hint: 'Give ideas to someone else.', emoji: '💡', autoCapitalize: false },
+      { text: 'practice', hint: 'Do it again to get better.', emoji: '🎯', autoCapitalize: false },
+      { text: 'listen', hint: 'Pay attention with your ears.', emoji: '👂', autoCapitalize: false },
+      { text: 'celebrate', hint: 'Enjoy something special.', emoji: '🎉', autoCapitalize: false }
+    ]
+  },
+  {
+    id: 'connectors',
+    label: 'Connectors',
+    color: '#ea4335',
+    entries: [
+      { text: 'because', hint: 'Give a reason for your idea.', emoji: '🧠', autoCapitalize: false, prependSpace: true },
+      { text: 'so', hint: 'Show what happens next.', emoji: '➡️', autoCapitalize: false, prependSpace: true },
+      { text: 'then', hint: 'Add the next step.', emoji: '⏩', autoCapitalize: false, prependSpace: true },
+      { text: 'after', hint: 'Tell what came later.', emoji: '🔁', autoCapitalize: false, prependSpace: true },
+      { text: 'but', hint: 'Show a different idea.', emoji: '🔄', autoCapitalize: false, prependSpace: true },
+      { text: 'also', hint: 'Add another idea.', emoji: '➕', autoCapitalize: false, prependSpace: true }
+    ]
+  },
+  {
+    id: 'places',
+    label: 'Places & time',
+    color: '#a142f4',
+    entries: [
+      { text: 'playground', hint: 'The place where you play.', emoji: '🛝', autoCapitalize: false },
+      { text: 'library', hint: 'A room with many books.', emoji: '📚', autoCapitalize: false },
+      { text: 'outside', hint: 'Out in the fresh air.', emoji: '🌤️', autoCapitalize: false },
+      { text: 'after school', hint: 'What happens when school finishes.', emoji: '🏡', replaceCurrent: false },
+      { text: 'during the lesson', hint: 'Explain what happened in learning time.', emoji: '🕒', replaceCurrent: false },
+      { text: 'in the playground', hint: 'Say where the action happened.', emoji: '🎠', replaceCurrent: false }
+    ]
+  }
+];
+
+export const nextWordMap = {
+  i: ['feel', 'can', 'will', 'want', 'am'],
+  we: ['are', 'can', 'will', 'learn'],
+  they: ['are', 'can', 'helped'],
+  my: ['friend', 'teacher', 'family'],
+  because: ['I', 'we', 'it'],
+  so: ['we', 'I', 'it'],
+  then: ['we', 'I'],
+  after: ['that', 'we'],
+  first: ['we', 'I'],
+  next: ['we', 'I'],
+  finally: ['we', 'I']
+};
+
+export const phraseContinuations = [
+  {
+    id: 'feelings',
+    label: 'Feeling ideas',
+    pattern: /i feel$/i,
+    suggestions: [
+      {
+        text: 'happy when',
+        hint: 'Share when this feeling happens.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'worried when',
+        hint: 'Explain what makes you unsure.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'proud because',
+        hint: 'Tell the reason you feel proud.',
+        prependSpace: true,
+        replaceCurrent: false
+      }
+    ]
+  },
+  {
+    id: 'can',
+    label: 'Action ideas',
+    pattern: /i can$/i,
+    suggestions: [
+      {
+        text: 'learn new words',
+        hint: 'Explain what you are learning.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'ask my teacher',
+        hint: 'Say who can help you.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'practice every day',
+        hint: 'Show how you get better.',
+        prependSpace: true,
+        replaceCurrent: false
+      }
+    ]
+  },
+  {
+    id: 'then',
+    label: 'Sequencing',
+    pattern: /then$/i,
+    suggestions: [
+      {
+        text: 'we',
+        hint: 'Add what happened next.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'I',
+        hint: 'Say what you did afterwards.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'after that',
+        hint: 'Use a time phrase to continue.',
+        prependSpace: true,
+        replaceCurrent: false
+      }
+    ]
+  },
+  {
+    id: 'because',
+    label: 'Reasoning',
+    pattern: /because$/i,
+    suggestions: [
+      {
+        text: 'I can understand',
+        hint: 'Explain what you now know.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'we worked together',
+        hint: 'Share how teamwork helped.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'it was new for me',
+        hint: 'Give a reason why it felt different.',
+        prependSpace: true,
+        replaceCurrent: false
+      }
+    ]
+  },
+  {
+    id: 'first',
+    label: 'Story order',
+    pattern: /first$/i,
+    suggestions: [
+      {
+        text: 'we',
+        hint: 'Explain who started.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'I',
+        hint: 'Describe your first step.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'First,',
+        hint: 'Use a comma after "First".',
+        replaceCurrent: true
+      }
+    ]
+  },
+  {
+    id: 'next',
+    label: 'Order clue',
+    pattern: /next$/i,
+    suggestions: [
+      {
+        text: 'we',
+        hint: 'Continue with the next action.',
+        prependSpace: true,
+        replaceCurrent: false
+      },
+      {
+        text: 'Next,',
+        hint: 'Add a comma to keep it neat.',
+        replaceCurrent: true
+      },
+      {
+        text: 'after that',
+        hint: 'Link to the next part.',
+        prependSpace: true,
+        replaceCurrent: false
+      }
+    ]
+  }
+];
+
+export const languageFrames = [
+  {
+    title: 'Feeling and reason',
+    frame: 'I feel ___ because ___',
+    description: 'Share a feeling and give a reason to explain it.'
+  },
+  {
+    title: 'Working together',
+    frame: 'First, we ___ . Then, we ___ .',
+    description: 'Use time words to show the order of events.'
+  },
+  {
+    title: 'Learning reflection',
+    frame: 'I found ___ tricky but I ___ to keep going.',
+    description: 'Explain a challenge and how you solved it.'
+  },
+  {
+    title: 'Future plan',
+    frame: 'Next time I will ___ so that ___',
+    description: 'Talk about your next steps and why they matter.'
+  }
+];
+
+export const focusQuestions = [
+  'What happened first, next and last?',
+  'How did you feel and why?',
+  'Who helped you during the learning?',
+  'What new words did you use today?',
+  'What will you try again next time?'
+];

--- a/src/index.css
+++ b/src/index.css
@@ -3,12 +3,20 @@
 @tailwind utilities;
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  color-scheme: light;
+  color: #202124;
+  background-color: #f1f3f4;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: #f1f3f4;
+}
+
+a {
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- redesign the application shell to mimic a Google Docs style workspace tailored to young EAL writers
- introduce contextual word-bank controls, smart predictions, language frames and focus questions driven by new data
- refresh styling and base styles to support the document canvas and right-rail scaffolding experience

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cea30bb5b48322abe84bca017f443f