### PR TITLE
Refactor app into EAL-friendly document editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "nspell": "^2.1.5",
         "papaparse": "^5.4.1",
         "postcss": "^8.4.49",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-rnd": "^10.4.14",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "nspell": "^2.1.5",
     "papaparse": "^5.4.1",
     "postcss": "^8.4.49",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-rnd": "^10.4.14",

--- a/src/App.css
+++ b/src/App.css
@@ -1,21 +1,523 @@
-/* Reset any default styles */
-#root {
+:root {
+  color: #202124;
+  font-family: 'Inter', 'Roboto', sans-serif;
+  background-color: #f1f3f4;
+}
+
+body {
   margin: 0;
+  background-color: #f1f3f4;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
   padding: 0;
-  width: 100%;
+  margin: -1px;
+  border: 0;
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-/* Custom styles for interactive elements */
-select {
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #f1f3f4;
+}
+
+.app-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1.75rem;
+  background: #f8f9fa;
+  border-bottom: 1px solid #dadce0;
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.app-toolbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: linear-gradient(135deg, #1a73e8, #4285f4);
+  box-shadow: 0 4px 12px rgba(26, 115, 232, 0.25);
+}
+
+.doc-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.doc-title-input {
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #202124;
+  padding: 0.1rem 0;
+}
+
+.doc-title-input:focus {
+  outline: none;
+  border-bottom: 1px solid #1a73e8;
+}
+
+.doc-menu {
+  display: flex;
+  gap: 1rem;
+  color: #5f6368;
+  font-size: 0.85rem;
+}
+
+.doc-menu span {
+  cursor: pointer;
+}
+
+.doc-menu span:hover {
+  color: #1a73e8;
+}
+
+.app-toolbar__right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.support-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  border: 1px solid #dadce0;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  color: #3c4043;
+  font-size: 0.85rem;
+}
+
+.support-selector label {
+  display: none;
+}
+
+.support-selector select {
+  border: none;
+  background: transparent;
+  font-size: 0.85rem;
+  color: inherit;
+  padding-right: 1.5rem;
   appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
   background-repeat: no-repeat;
-  background-position: right 0.5rem center;
-  background-size: 1em;
-  padding-right: 2.5rem;
+  background-position: right 0.15rem center;
+  background-size: 1rem;
 }
 
-/* Smooth transitions for theme changes */
-* {
-  transition: background-color 0.3s ease, color 0.3s ease;
+.support-selector select:focus {
+  outline: none;
+}
+
+.share-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  background: #1a73e8;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(26, 115, 232, 0.35);
+}
+
+.share-button:hover {
+  background: #1765cc;
+}
+
+.format-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 1.75rem;
+  background: #fff;
+  border-bottom: 1px solid #dadce0;
+  position: sticky;
+  top: 64px;
+  z-index: 15;
+}
+
+.format-toolbar__divider {
+  width: 1px;
+  height: 24px;
+  background: #dadce0;
+  margin: 0 0.35rem;
+}
+
+.format-toolbar__spacer {
+  flex: 1;
+}
+
+.format-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  color: #3c4043;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.format-button:hover {
+  background: rgba(26, 115, 232, 0.08);
+  border-color: rgba(26, 115, 232, 0.12);
+}
+
+.doc-layout {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1.5rem 1.75rem 2.5rem;
+}
+
+.doc-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.suggestion-bar {
+  background: #fff;
+  border-radius: 12px;
+  border: 1px solid #e8eaed;
+  box-shadow: 0 4px 12px rgba(60, 64, 67, 0.1);
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.suggestion-bar__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #1a73e8;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.suggestion-bar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.suggestion-chip {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid #c6dafc;
+  background: #e8f0fe;
+  color: #1a73e8;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.suggestion-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(26, 115, 232, 0.25);
+}
+
+.suggestion-empty {
+  color: #5f6368;
+  font-size: 0.85rem;
+}
+
+.support-badge {
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.support-badge--beginner {
+  background: #e8f5e9;
+  color: #1b5e20;
+}
+
+.support-badge--intermediate {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.support-badge--advanced {
+  background: #fce4ec;
+  color: #ad1457;
+}
+
+.doc-page-wrapper {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.95));
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.15);
+  border: 1px solid #e8eaed;
+}
+
+.doc-page {
+  min-height: 900px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #202124;
+  outline: none;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(218, 220, 224, 0.7);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.doc-page:focus {
+  box-shadow: inset 0 0 0 2px #1a73e8;
+}
+
+.doc-page[data-placeholder][data-has-content='false']::before {
+  content: attr(data-placeholder);
+  color: #9aa0a6;
+  position: absolute;
+  top: 1.5rem;
+  left: 1.5rem;
+  pointer-events: none;
+}
+
+.doc-status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #5f6368;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #e8eaed;
+}
+
+.doc-status-bar__tip {
+  color: #1a73e8;
+}
+
+.scaffold-panel {
+  width: 320px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid #e8eaed;
+  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.12);
+}
+
+.scaffold-panel__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.scaffold-panel__header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.scaffold-panel__header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: #5f6368;
+}
+
+.word-bank-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.word-bank-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #dadce0;
+  background: #f8f9fa;
+  color: #3c4043;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.word-bank-tab__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.word-bank-tab--active {
+  border-color: #1a73e8;
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+
+.word-bank-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 320px;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.word-bank-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  border: 1px solid #e8eaed;
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.word-bank-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(26, 115, 232, 0.18);
+  border-color: #c6dafc;
+}
+
+.word-bank-item__text {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1a73e8;
+}
+
+.word-bank-item__hint {
+  font-size: 0.75rem;
+  color: #5f6368;
+  margin-top: 0.2rem;
+}
+
+.word-bank-empty {
+  color: #5f6368;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.support-card {
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(26, 115, 232, 0.08), rgba(26, 115, 232, 0.15));
+  padding: 1rem;
+  color: #174ea6;
+  border: 1px solid rgba(26, 115, 232, 0.15);
+}
+
+.support-card h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.support-card p {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+}
+
+.support-card ul {
+  padding-left: 1.1rem;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.support-card li {
+  margin-bottom: 0.3rem;
+}
+
+@media (max-width: 1200px) {
+  .doc-layout {
+    flex-direction: column;
+  }
+
+  .scaffold-panel {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-toolbar,
+  .format-toolbar {
+    position: static;
+  }
+
+  .doc-layout {
+    padding: 1rem;
+  }
+
+  .doc-wrapper {
+    width: 100%;
+  }
+
+  .app-toolbar__right {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .support-selector {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 600px) {
+  .doc-menu {
+    display: none;
+  }
+
+  .format-toolbar {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .format-toolbar__spacer {
+    display: none;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,8 @@
-import SentenceBuilder from './components/SentenceBuilder';
 import './App.css';
+import EALDocs from './components/EALDocs';
 
 function App() {
-  return (
-    <div className="min-h-screen bg-white">
-      <main className="h-screen">
-        <SentenceBuilder />
-      </main>
-    </div>
-  );
+  return <EALDocs />;
 }
 
 export default App;

--- a/src/components/EALDocs.jsx
+++ b/src/components/EALDocs.jsx
@@ -1,0 +1,567 @@
+import PropTypes from 'prop-types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  Bold,
+  BookOpen,
+  Download,
+  FileText,
+  Highlighter,
+  Italic,
+  Languages,
+  List,
+  ListOrdered,
+  Share2,
+  Sparkles,
+  Underline,
+  Upload
+} from 'lucide-react';
+
+import {
+  determiners,
+  filterItemsByLevel,
+  flattenWordBank,
+  highFrequencyWords,
+  levelRank,
+  linkingVerbs,
+  modalHelpers,
+  pronounFriendlyVerbs,
+  pronouns,
+  questionOpeners,
+  supportiveSentenceFrames,
+  timeMarkers,
+  wordBankCategories
+} from '../data/ealWordBank';
+
+const ToolbarButton = ({ icon: Icon, label, onClick }) => (
+  <button type="button" className="format-button" onClick={onClick} aria-label={label} title={label}>
+    <Icon size={16} />
+  </button>
+);
+
+const SuggestionChip = ({ text, onSelect }) => (
+  <button type="button" className="suggestion-chip" onClick={() => onSelect(text)}>
+    {text}
+  </button>
+);
+
+const WordBankItem = ({ item, onInsert }) => (
+  <button type="button" className="word-bank-item" onClick={() => onInsert(item)}>
+    <span className="word-bank-item__text">{item.text}</span>
+    {item.hint ? <span className="word-bank-item__hint">{item.hint}</span> : null}
+  </button>
+);
+
+const SupportLevelBadge = ({ level }) => {
+  const levelLabels = {
+    beginner: 'Beginner',
+    intermediate: 'Intermediate',
+    advanced: 'Advanced'
+  };
+
+  return <span className={`support-badge support-badge--${level}`}>{levelLabels[level]}</span>;
+};
+
+ToolbarButton.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired
+};
+
+SuggestionChip.propTypes = {
+  text: PropTypes.string.isRequired,
+  onSelect: PropTypes.func.isRequired
+};
+
+WordBankItem.propTypes = {
+  item: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    hint: PropTypes.string,
+    level: PropTypes.string
+  }).isRequired,
+  onInsert: PropTypes.func.isRequired
+};
+
+SupportLevelBadge.propTypes = {
+  level: PropTypes.oneOf(['beginner', 'intermediate', 'advanced']).isRequired
+};
+
+const getLevelRank = (level) => levelRank[level] ?? 0;
+
+const normaliseText = (text) => text?.toLowerCase().trim() ?? '';
+
+const ensureEditorFocus = (editor) => {
+  if (editor && document.activeElement !== editor) {
+    editor.focus();
+  }
+};
+
+const EALDocs = () => {
+  const editorRef = useRef(null);
+  const fileInputRef = useRef(null);
+  const [docTitle, setDocTitle] = useState('Untitled EAL Doc');
+  const [supportLevel, setSupportLevel] = useState('beginner');
+  const [activeCategory, setActiveCategory] = useState(wordBankCategories[0].id);
+  const [wordCount, setWordCount] = useState(0);
+  const [focusTip, setFocusTip] = useState('Start by choosing a sentence starter from the bank.');
+  const [plainText, setPlainText] = useState('');
+  const [caretContext, setCaretContext] = useState({
+    prefix: '',
+    previousWord: '',
+    textBeforeCaret: ''
+  });
+
+  const categoriesForLevel = useMemo(
+    () =>
+      wordBankCategories.map((category) => ({
+        ...category,
+        items: filterItemsByLevel(category.items, supportLevel)
+      })),
+    [supportLevel]
+  );
+
+  const categoryLookup = useMemo(() => {
+    const lookup = new Map();
+    categoriesForLevel.forEach((category) => {
+      lookup.set(category.id, category);
+    });
+    return lookup;
+  }, [categoriesForLevel]);
+
+  useEffect(() => {
+    const availableCategories = categoriesForLevel.filter((category) => category.items.length > 0);
+    if (!availableCategories.length) {
+      return;
+    }
+    if (!availableCategories.find((category) => category.id === activeCategory)) {
+      setActiveCategory(availableCategories[0].id);
+    }
+  }, [activeCategory, categoriesForLevel]);
+
+  const uniqueWordList = useMemo(
+    () => flattenWordBank(wordBankCategories, supportLevel),
+    [supportLevel]
+  );
+
+  const updateCaretContext = useCallback(() => {
+    const editor = editorRef.current;
+    const selection = window.getSelection();
+
+    if (!editor || !selection || !selection.rangeCount) {
+      setCaretContext({ prefix: '', previousWord: '', textBeforeCaret: '' });
+      return;
+    }
+
+    const focusNode = selection.focusNode;
+    if (!editor.contains(focusNode)) {
+      setCaretContext({ prefix: '', previousWord: '', textBeforeCaret: '' });
+      return;
+    }
+
+    const range = selection.getRangeAt(0).cloneRange();
+    range.selectNodeContents(editor);
+    range.setEnd(selection.focusNode, selection.focusOffset);
+    const text = range.toString().replace(/\u00a0/g, ' ');
+    const trimmed = text.replace(/\s+/g, ' ').trimEnd();
+
+    const prefixMatch = trimmed.match(/([\p{L}'’-]+)$/u);
+    const prefix = prefixMatch ? prefixMatch[1] : '';
+    const beforePrefix = prefixMatch ? trimmed.slice(0, -prefix.length) : trimmed;
+    const previousMatch = beforePrefix.trim().match(/([\p{L}'’-]+)$/u);
+    const previousWord = previousMatch ? previousMatch[1] : '';
+
+    setCaretContext({ prefix, previousWord, textBeforeCaret: trimmed });
+  }, []);
+
+  useEffect(() => {
+    const handleSelectionChange = () => updateCaretContext();
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => document.removeEventListener('selectionchange', handleSelectionChange);
+  }, [updateCaretContext]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (editor) {
+      editor.dataset.hasContent = 'false';
+    }
+  }, []);
+
+  const applyCommand = useCallback((command, value) => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    ensureEditorFocus(editor);
+    document.execCommand(command, false, value);
+    updateCaretContext();
+  }, [updateCaretContext]);
+
+  const insertTextAtCursor = useCallback(
+    (text) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return;
+      }
+      ensureEditorFocus(editor);
+      document.execCommand('insertText', false, text);
+      updateCaretContext();
+    },
+    [updateCaretContext]
+  );
+
+  const handleWordInsert = useCallback(
+    (item) => {
+      const addition = item.text.endsWith(' ') ? item.text : `${item.text} `;
+      insertTextAtCursor(addition);
+    },
+    [insertTextAtCursor]
+  );
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileImport = useCallback(
+    (event) => {
+      const [file] = event.target.files ?? [];
+      if (!file) {
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        const text = typeof reader.result === 'string' ? reader.result : '';
+        const editor = editorRef.current;
+        if (!editor) {
+          return;
+        }
+        editor.innerText = text;
+        const cleaned = text.replace(/\u00a0/g, ' ');
+        setPlainText(cleaned);
+        const words = cleaned.trim() ? cleaned.trim().split(/\s+/) : [];
+        setWordCount(words.length);
+        editor.dataset.hasContent = words.length > 0 ? 'true' : 'false';
+        updateCaretContext();
+      };
+
+      reader.readAsText(file);
+      // reset input so the same file can be chosen again
+      event.target.value = '';
+    },
+    [updateCaretContext]
+  );
+
+  const handleExport = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    const content = editor.innerText ?? '';
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    const safeTitle = docTitle.trim() || 'eal-doc';
+    link.download = `${safeTitle}.txt`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [docTitle]);
+
+  const suggestions = useMemo(() => {
+    const results = [];
+    const prefix = normaliseText(caretContext.prefix);
+    const previous = normaliseText(caretContext.previousWord);
+    const textBefore = caretContext.textBeforeCaret.trim();
+
+    if (prefix) {
+      const matches = uniqueWordList.filter((word) => {
+        const lower = normaliseText(word);
+        return lower.startsWith(prefix) && lower !== prefix;
+      });
+      results.push(...matches.slice(0, 5));
+    }
+
+    const isNewSentence = !textBefore || /[.!?]\s*$/.test(textBefore);
+    let contextualPool = [];
+
+    if (isNewSentence) {
+      contextualPool = supportiveSentenceFrames;
+    } else if (pronouns.includes(previous)) {
+      contextualPool = pronounFriendlyVerbs;
+    } else if (determiners.includes(previous)) {
+      contextualPool = categoryLookup.get('descriptions')?.items.map((item) => item.text) ?? [];
+      contextualPool = contextualPool.concat(categoryLookup.get('people')?.items.map((item) => item.text) ?? []);
+    } else if (linkingVerbs.includes(previous)) {
+      contextualPool = categoryLookup.get('descriptions')?.items.map((item) => item.text) ?? [];
+    } else if (questionOpeners.includes(previous)) {
+      contextualPool = categoryLookup.get('people')?.items.map((item) => item.text) ?? [];
+    } else if (timeMarkers.includes(previous)) {
+      contextualPool = categoryLookup.get('actions')?.items.map((item) => item.text) ?? [];
+    } else if (modalHelpers.includes(previous)) {
+      contextualPool = categoryLookup.get('actions')?.items.map((item) => item.text) ?? [];
+    } else {
+      contextualPool = highFrequencyWords;
+    }
+
+    contextualPool.forEach((item) => {
+      const word = typeof item === 'string' ? item : item.text;
+      if (!results.find((existing) => existing.toLowerCase() === word.toLowerCase())) {
+        results.push(word);
+      }
+    });
+
+    return results.slice(0, 6);
+  }, [caretContext, categoryLookup, uniqueWordList]);
+
+  const handleSuggestionSelect = useCallback(
+    (suggestion) => {
+      const editor = editorRef.current;
+      if (!editor) {
+        return;
+      }
+
+      const prefix = caretContext.prefix;
+      ensureEditorFocus(editor);
+
+      if (prefix && suggestion.toLowerCase().startsWith(prefix.toLowerCase())) {
+        const remainder = suggestion.slice(prefix.length);
+        const insertion = remainder.endsWith(' ') ? remainder : `${remainder} `;
+        document.execCommand('insertText', false, insertion);
+      } else {
+        const needsSpace = !/[.!?,]$/.test(suggestion);
+        const addition = needsSpace ? `${suggestion} ` : suggestion;
+        document.execCommand('insertText', false, addition);
+      }
+
+      updateCaretContext();
+    },
+    [caretContext.prefix, updateCaretContext]
+  );
+
+  const handleEditorInput = useCallback(
+    (event) => {
+      const currentText = event.currentTarget.innerText.replace(/\u00a0/g, ' ');
+      setPlainText(currentText);
+      const words = currentText.trim() ? currentText.trim().split(/\s+/) : [];
+      setWordCount(words.length);
+
+      const editor = editorRef.current;
+      if (editor) {
+        editor.dataset.hasContent = words.length > 0 ? 'true' : 'false';
+      }
+
+      updateCaretContext();
+    },
+    [updateCaretContext]
+  );
+
+  const handleEditorFocus = useCallback(() => {
+    updateCaretContext();
+  }, [updateCaretContext]);
+
+  useEffect(() => {
+    const trimmed = plainText.trim();
+    if (!trimmed) {
+      setFocusTip('Start by choosing a sentence starter from the word bank.');
+      return;
+    }
+
+    const wordTotal = trimmed.split(/\s+/).length;
+    if (wordTotal < 5) {
+      setFocusTip('Can you add a describing word to give more detail?');
+      return;
+    }
+
+    if (!/[.!?]$/.test(trimmed)) {
+      setFocusTip('Finish the sentence with a full stop, question mark, or exclamation mark.');
+      return;
+    }
+
+    if (getLevelRank(supportLevel) >= levelRank.intermediate) {
+      setFocusTip('Try adding a connector like "because" or "after that" to join ideas.');
+      return;
+    }
+
+    setFocusTip('Great writing! Could you add how the person feels?');
+  }, [plainText, supportLevel]);
+
+  const activeCategoryData = categoryLookup.get(activeCategory);
+  const activeItems = activeCategoryData?.items ?? [];
+
+  return (
+    <div className="app-shell">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".txt"
+        className="visually-hidden"
+        onChange={handleFileImport}
+      />
+      <header className="app-toolbar">
+        <div className="app-toolbar__left">
+          <div className="app-logo">
+            <FileText size={20} />
+          </div>
+          <div className="doc-meta">
+            <input
+              className="doc-title-input"
+              value={docTitle}
+              onChange={(event) => setDocTitle(event.target.value)}
+              aria-label="Document title"
+            />
+            <nav className="doc-menu">
+              <span>File</span>
+              <span>Edit</span>
+              <span>Insert</span>
+              <span>Format</span>
+              <span>Tools</span>
+              <span>Help</span>
+            </nav>
+          </div>
+        </div>
+        <div className="app-toolbar__right">
+          <div className="support-selector">
+            <Languages size={16} />
+            <label htmlFor="support-level">Support level</label>
+            <select
+              id="support-level"
+              value={supportLevel}
+              onChange={(event) => setSupportLevel(event.target.value)}
+            >
+              <option value="beginner">Beginner</option>
+              <option value="intermediate">Intermediate</option>
+              <option value="advanced">Advanced</option>
+            </select>
+          </div>
+          <button type="button" className="share-button">
+            <Share2 size={16} />
+            Share support doc
+          </button>
+        </div>
+      </header>
+
+      <div className="format-toolbar">
+        <ToolbarButton icon={Bold} label="Bold" onClick={() => applyCommand('bold')} />
+        <ToolbarButton icon={Italic} label="Italic" onClick={() => applyCommand('italic')} />
+        <ToolbarButton icon={Underline} label="Underline" onClick={() => applyCommand('underline')} />
+        <ToolbarButton icon={Highlighter} label="Highlight" onClick={() => applyCommand('hiliteColor', '#fff3b0')} />
+        <div className="format-toolbar__divider" />
+        <ToolbarButton icon={AlignLeft} label="Align left" onClick={() => applyCommand('justifyLeft')} />
+        <ToolbarButton icon={AlignCenter} label="Align centre" onClick={() => applyCommand('justifyCenter')} />
+        <ToolbarButton icon={AlignJustify} label="Justify" onClick={() => applyCommand('justifyFull')} />
+        <div className="format-toolbar__divider" />
+        <ToolbarButton icon={List} label="Bullet list" onClick={() => applyCommand('insertUnorderedList')} />
+        <ToolbarButton icon={ListOrdered} label="Numbered list" onClick={() => applyCommand('insertOrderedList')} />
+        <div className="format-toolbar__spacer" />
+        <button type="button" className="format-button" onClick={handleImportClick}>
+          <Upload size={16} />
+          <span>Import</span>
+        </button>
+        <button type="button" className="format-button" onClick={handleExport}>
+          <Download size={16} />
+          <span>Export</span>
+        </button>
+      </div>
+
+      <div className="doc-layout">
+        <div className="doc-wrapper">
+          <div className="suggestion-bar">
+            <div className="suggestion-bar__header">
+              <Sparkles size={16} />
+              <span>Smart suggestions</span>
+              <SupportLevelBadge level={supportLevel} />
+            </div>
+            <div className="suggestion-bar__chips">
+              {suggestions.length ? (
+                suggestions.map((suggestion) => (
+                  <SuggestionChip
+                    key={`${suggestion}-${supportLevel}`}
+                    text={suggestion}
+                    onSelect={handleSuggestionSelect}
+                  />
+                ))
+              ) : (
+                <span className="suggestion-empty">Type a word to see ideas appear here.</span>
+              )}
+            </div>
+          </div>
+
+          <div className="doc-page-wrapper">
+            <div
+              ref={editorRef}
+              className="doc-page"
+              contentEditable
+              role="textbox"
+              aria-label="Document editor"
+              spellCheck
+              data-placeholder="Type your ideas here..."
+              onInput={handleEditorInput}
+              onKeyUp={updateCaretContext}
+              onMouseUp={updateCaretContext}
+              onFocus={handleEditorFocus}
+              suppressContentEditableWarning
+            />
+          </div>
+
+          <div className="doc-status-bar">
+            <span>{wordCount} {wordCount === 1 ? 'word' : 'words'}</span>
+            <span className="doc-status-bar__tip">{focusTip}</span>
+          </div>
+        </div>
+
+        <aside className="scaffold-panel">
+          <div className="scaffold-panel__header">
+            <BookOpen size={18} />
+            <div>
+              <h2>Word bank</h2>
+              <p>Tap a word or phrase to add it to your document.</p>
+            </div>
+          </div>
+
+          <div className="word-bank-tabs">
+            {categoriesForLevel
+              .filter((category) => category.items.length > 0)
+              .map((category) => (
+                <button
+                  key={category.id}
+                  type="button"
+                  className={`word-bank-tab ${activeCategory === category.id ? 'word-bank-tab--active' : ''}`}
+                  onClick={() => setActiveCategory(category.id)}
+                >
+                  <span className="word-bank-tab__dot" style={{ backgroundColor: category.color }} />
+                  {category.label}
+                </button>
+              ))}
+          </div>
+
+          <div className="word-bank-items">
+            {activeItems.length ? (
+              activeItems.map((item) => (
+                <WordBankItem key={item.text} item={item} onInsert={handleWordInsert} />
+              ))
+            ) : (
+              <p className="word-bank-empty">No words at this support level yet. Try a different level.</p>
+            )}
+          </div>
+
+          <div className="support-card">
+            <h3>Writing coach</h3>
+            <p>{focusTip}</p>
+            <ul>
+              <li>Use the connectors tab to join short sentences.</li>
+              <li>Try saying your sentence aloud before writing it.</li>
+              <li>Remember to check punctuation at the end.</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default EALDocs;
+

--- a/src/components/SentenceBuilder.jsx
+++ b/src/components/SentenceBuilder.jsx
@@ -428,11 +428,9 @@ const SentenceBuilder = () => {
   };
 
   // Closes context menu on outside click
-  const closeContextMenu = () => {
-    if (contextMenu.visible) {
-      setContextMenu({ ...contextMenu, visible: false });
-    }
-  };
+  const closeContextMenu = useCallback(() => {
+    setContextMenu((prev) => (prev.visible ? { ...prev, visible: false } : prev));
+  }, []);
 
   // Hide context menu on scroll or window resize
   useEffect(() => {
@@ -443,7 +441,7 @@ const SentenceBuilder = () => {
       window.removeEventListener('scroll', handleScrollOrResize);
       window.removeEventListener('resize', handleScrollOrResize);
     };
-  }, [contextMenu.visible]);
+  }, [closeContextMenu]);
 
   // Hide context menu on any window click
   useEffect(() => {
@@ -451,7 +449,7 @@ const SentenceBuilder = () => {
     return () => {
       window.removeEventListener('click', closeContextMenu);
     };
-  }, []);
+  }, [closeContextMenu]);
 
   /**
    * ---------------------------

--- a/src/data/ealWordBank.js
+++ b/src/data/ealWordBank.js
@@ -1,0 +1,260 @@
+export const levelRank = {
+  beginner: 0,
+  intermediate: 1,
+  advanced: 2
+};
+
+export const wordBankCategories = [
+  {
+    id: 'sentence_starters',
+    label: 'Sentence starters',
+    color: '#1a73e8',
+    description: 'Open your ideas with friendly sentence beginnings.',
+    items: [
+      { text: 'I can see', level: 'beginner', hint: 'Use for describing what is in front of you.' },
+      { text: 'This is', level: 'beginner', hint: 'Introduce a person, place, or thing.' },
+      { text: 'Today I', level: 'beginner', hint: 'Talk about something that is happening now.' },
+      { text: 'I like to', level: 'beginner', hint: 'Share something you enjoy doing.' },
+      { text: 'My favourite part is', level: 'intermediate', hint: 'Explain the best part of your idea.' },
+      { text: 'When I', level: 'intermediate', hint: 'Begin a sentence about a time something happened.' },
+      { text: 'I would like', level: 'intermediate', hint: 'Use when you are making a polite request.' },
+      { text: 'In my opinion', level: 'advanced', hint: 'Share your thinking or point of view.' }
+    ]
+  },
+  {
+    id: 'people',
+    label: 'People & characters',
+    color: '#0b8043',
+    description: 'Choose who is in your sentence.',
+    items: [
+      { text: 'my friend', level: 'beginner', hint: 'A person you know and like.' },
+      { text: 'the teacher', level: 'beginner', hint: 'An adult who helps you learn.' },
+      { text: 'my family', level: 'beginner', hint: 'Use when more than one person is involved.' },
+      { text: 'a scientist', level: 'intermediate', hint: 'Someone who investigates and discovers things.' },
+      { text: 'the explorer', level: 'intermediate', hint: 'A character who travels to new places.' },
+      { text: 'a kind helper', level: 'beginner', hint: 'Someone who gives support.' },
+      { text: 'the community', level: 'advanced', hint: 'Talk about many people together.' }
+    ]
+  },
+  {
+    id: 'actions',
+    label: 'Actions & verbs',
+    color: '#9334e6',
+    description: 'Tell what the person or object is doing.',
+    items: [
+      { text: 'is running', level: 'beginner', hint: 'Moving quickly with your legs.' },
+      { text: 'is learning', level: 'beginner', hint: 'Finding out new information.' },
+      { text: 'can jump', level: 'beginner', hint: 'Able to move off the ground.' },
+      { text: 'wants to explore', level: 'intermediate', hint: 'Feels excited to look around a new place.' },
+      { text: 'is carefully drawing', level: 'intermediate', hint: 'Doing an action slowly and with care.' },
+      { text: 'is thinking about', level: 'intermediate', hint: 'Planning or imagining something.' },
+      { text: 'is investigating', level: 'advanced', hint: 'Looking closely to find clues or answers.' }
+    ]
+  },
+  {
+    id: 'descriptions',
+    label: 'Describing words',
+    color: '#ff8c00',
+    description: 'Add detail so your reader can imagine the scene.',
+    items: [
+      { text: 'bright and colourful', level: 'beginner', hint: 'Full of light and colour.' },
+      { text: 'very quiet', level: 'beginner', hint: 'Almost no sound at all.' },
+      { text: 'soft and fluffy', level: 'beginner', hint: 'Gentle to touch like a cloud.' },
+      { text: 'excited', level: 'beginner', hint: 'Feeling happy energy.' },
+      { text: 'brave', level: 'intermediate', hint: 'Ready to do something even if it is difficult.' },
+      { text: 'curious', level: 'intermediate', hint: 'Wanting to know more about something.' },
+      { text: 'spectacular', level: 'advanced', hint: 'So amazing that it stands out.' }
+    ]
+  },
+  {
+    id: 'connectors',
+    label: 'Connectors',
+    color: '#00acc1',
+    description: 'Join ideas together so they flow smoothly.',
+    items: [
+      { text: 'and', level: 'beginner', hint: 'Add another idea to your sentence.' },
+      { text: 'because', level: 'beginner', hint: 'Explain the reason for something.' },
+      { text: 'so', level: 'beginner', hint: 'Show the result of an action.' },
+      { text: 'but', level: 'beginner', hint: 'Show a different idea or change.' },
+      { text: 'after that', level: 'intermediate', hint: 'Move your story forward in time.' },
+      { text: 'so that', level: 'intermediate', hint: 'Explain the purpose of an action.' },
+      { text: 'however', level: 'advanced', hint: 'Introduce a contrasting idea in formal writing.' },
+      { text: 'therefore', level: 'advanced', hint: 'Show the result of earlier ideas.' }
+    ]
+  },
+  {
+    id: 'time',
+    label: 'Time & sequence',
+    color: '#ff7043',
+    description: 'Explain when something happens.',
+    items: [
+      { text: 'first', level: 'beginner', hint: 'Use for the beginning of a sequence.' },
+      { text: 'next', level: 'beginner', hint: 'Show what happens after the first thing.' },
+      { text: 'then', level: 'beginner', hint: 'Add another step in the order.' },
+      { text: 'finally', level: 'intermediate', hint: 'Finish a sequence or set of instructions.' },
+      { text: 'today', level: 'beginner', hint: 'Something happening now.' },
+      { text: 'yesterday', level: 'intermediate', hint: 'Something that happened in the past.' },
+      { text: 'tomorrow', level: 'intermediate', hint: 'Something that will happen in the future.' }
+    ]
+  },
+  {
+    id: 'places',
+    label: 'Places & settings',
+    color: '#1a73e8',
+    description: 'Choose where the action takes place.',
+    items: [
+      { text: 'in the classroom', level: 'beginner', hint: 'Inside a room where you learn.' },
+      { text: 'at the park', level: 'beginner', hint: 'Outside where you can play.' },
+      { text: 'near the library', level: 'beginner', hint: 'Close to the place with many books.' },
+      { text: 'on the playground', level: 'beginner', hint: 'Where children can play outside.' },
+      { text: 'inside the laboratory', level: 'intermediate', hint: 'A place for science experiments.' },
+      { text: 'around the community', level: 'intermediate', hint: 'Different places near where people live.' },
+      { text: 'across the mountains', level: 'advanced', hint: 'Far away in a natural setting.' }
+    ]
+  },
+  {
+    id: 'feelings',
+    label: 'Feelings',
+    color: '#d81b60',
+    description: 'Describe how someone feels.',
+    items: [
+      { text: 'happy', level: 'beginner', hint: 'Feeling good and smiling.' },
+      { text: 'nervous', level: 'beginner', hint: 'A little worried about what will happen.' },
+      { text: 'proud', level: 'beginner', hint: 'Feeling pleased with yourself or others.' },
+      { text: 'curious', level: 'intermediate', hint: 'Wanting to find out more.' },
+      { text: 'calm', level: 'intermediate', hint: 'Feeling peaceful and relaxed.' },
+      { text: 'determined', level: 'advanced', hint: 'Not giving up even when it is hard.' }
+    ]
+  },
+  {
+    id: 'classroom_language',
+    label: 'Classroom language',
+    color: '#5f6368',
+    description: 'Useful phrases for asking for help.',
+    items: [
+      { text: 'Can you help me?', level: 'beginner', hint: 'Politely ask for support.' },
+      { text: 'Please repeat that.', level: 'beginner', hint: 'Ask to hear the information again.' },
+      { text: 'I do not understand yet.', level: 'beginner', hint: 'Share that you need more explanation.' },
+      { text: 'May I check with a partner?', level: 'intermediate', hint: 'Ask to work together to understand.' },
+      { text: 'Could you show me an example?', level: 'intermediate', hint: 'Ask to see how something is done.' },
+      { text: 'I would like a glossary, please.', level: 'advanced', hint: 'Ask for vocabulary support politely.' }
+    ]
+  }
+];
+
+export const supportiveSentenceFrames = [
+  'I can see',
+  'I feel',
+  'I would like',
+  'I think',
+  'This text is about',
+  'First',
+  'Next',
+  'After that'
+];
+
+export const highFrequencyWords = [
+  'and',
+  'then',
+  'also',
+  'because',
+  'so',
+  'but',
+  'next',
+  'after that',
+  'for example',
+  'finally'
+];
+
+export const pronouns = ['i', 'we', 'they', 'he', 'she', 'it', 'you'];
+
+export const determiners = [
+  'a',
+  'an',
+  'the',
+  'this',
+  'that',
+  'these',
+  'those',
+  'my',
+  'your',
+  'our',
+  'his',
+  'her',
+  'their',
+  'some',
+  'many'
+];
+
+export const linkingVerbs = [
+  'am',
+  'is',
+  'are',
+  'was',
+  'were',
+  'feel',
+  'feels',
+  'felt',
+  'seem',
+  'seems',
+  'look',
+  'looks',
+  'sound',
+  'sounds'
+];
+
+export const timeMarkers = [
+  'first',
+  'next',
+  'then',
+  'after',
+  'before',
+  'later',
+  'finally',
+  'today',
+  'yesterday',
+  'tomorrow'
+];
+
+export const questionOpeners = ['who', 'what', 'where', 'when', 'why', 'how', 'which'];
+
+export const modalHelpers = ['can', 'could', 'should', 'might', 'will'];
+
+export const pronounFriendlyVerbs = [
+  'am',
+  'are',
+  'like',
+  'want',
+  'need',
+  'can',
+  'love',
+  'enjoy'
+];
+
+export const filterItemsByLevel = (items, level) => {
+  const targetRank = levelRank[level] ?? 0;
+  return items.filter((item) => {
+    const itemLevel = item.level ?? 'beginner';
+    if (itemLevel === 'all') {
+      return true;
+    }
+    const itemRank = levelRank[itemLevel] ?? 0;
+    return itemRank <= targetRank;
+  });
+};
+
+export const flattenWordBank = (categories, level) => {
+  const words = new Set();
+  categories.forEach((category) => {
+    filterItemsByLevel(category.items, level).forEach((item) => {
+      words.add(item.text);
+    });
+  });
+  supportiveSentenceFrames.forEach((frame) => words.add(frame));
+  highFrequencyWords.forEach((word) => words.add(word));
+  return Array.from(words);
+};
+
+export const getCategoryById = (id) =>
+  wordBankCategories.find((category) => category.id === id);
+


### PR DESCRIPTION
## Summary
- replace the entry point with a Google Docs–style document editor tailored for EAL writers, including predictive suggestions, adaptive support levels, and word bank integration
- introduce a structured EAL vocabulary dataset to drive contextual hints, scaffolds, and suggestion logic
- refresh global styling to mirror Docs layout and support the new helper panels and status surfaces

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea30bb5b48322abe84bca017f443f