### PR TITLE
Enhance predictive writing assistant with grammar, spellcheck, and TTS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,7 @@
   color: #202124;
   font-family: 'Inter', 'Roboto', sans-serif;
   background-color: #f1f3f4;
+  font-size: 18px;
 }
 
 body {
@@ -32,14 +33,15 @@ body {
   background-color: #f1f3f4;
 }
 
+
 .app-toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 1.75rem;
+  padding: 1rem 2.5rem;
   background: #f8f9fa;
   border-bottom: 1px solid #dadce0;
-  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.1);
+  box-shadow: 0 2px 8px rgba(60, 64, 67, 0.12);
   position: sticky;
   top: 0;
   z-index: 20;
@@ -48,19 +50,19 @@ body {
 .app-toolbar__left {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1.25rem;
 }
 
 .app-logo {
-  width: 36px;
-  height: 36px;
-  border-radius: 8px;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
   background: linear-gradient(135deg, #1a73e8, #4285f4);
-  box-shadow: 0 4px 12px rgba(26, 115, 232, 0.25);
+  box-shadow: 0 6px 18px rgba(26, 115, 232, 0.25);
 }
 
 .doc-meta {
@@ -72,7 +74,7 @@ body {
 .doc-title-input {
   border: none;
   background: transparent;
-  font-size: 1rem;
+  font-size: 1.35rem;
   font-weight: 600;
   color: #202124;
   padding: 0.1rem 0;
@@ -85,9 +87,9 @@ body {
 
 .doc-menu {
   display: flex;
-  gap: 1rem;
+  gap: 1.25rem;
   color: #5f6368;
-  font-size: 0.85rem;
+  font-size: 1rem;
 }
 
 .doc-menu span {
@@ -101,19 +103,19 @@ body {
 .app-toolbar__right {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .support-selector {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   background: #fff;
   border: 1px solid #dadce0;
   border-radius: 999px;
-  padding: 0.35rem 0.9rem;
+  padding: 0.5rem 1.5rem;
   color: #3c4043;
-  font-size: 0.85rem;
+  font-size: 1rem;
 }
 
 .support-selector label {
@@ -123,9 +125,9 @@ body {
 .support-selector select {
   border: none;
   background: transparent;
-  font-size: 0.85rem;
+  font-size: 1rem;
   color: inherit;
-  padding-right: 1.5rem;
+  padding-right: 1.75rem;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -142,15 +144,16 @@ body {
 .share-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
   border: none;
   background: #1a73e8;
   color: #fff;
   border-radius: 999px;
-  padding: 0.45rem 1.1rem;
+  padding: 0.6rem 1.6rem;
   font-weight: 600;
+  font-size: 1rem;
   cursor: pointer;
-  box-shadow: 0 1px 2px rgba(26, 115, 232, 0.35);
+  box-shadow: 0 3px 10px rgba(26, 115, 232, 0.25);
 }
 
 .share-button:hover {
@@ -160,20 +163,20 @@ body {
 .format-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 1.75rem;
+  gap: 0.5rem;
+  padding: 0.8rem 2.5rem;
   background: #fff;
   border-bottom: 1px solid #dadce0;
   position: sticky;
-  top: 64px;
+  top: 92px;
   z-index: 15;
 }
 
 .format-toolbar__divider {
   width: 1px;
-  height: 24px;
+  height: 32px;
   background: #dadce0;
-  margin: 0 0.35rem;
+  margin: 0 0.5rem;
 }
 
 .format-toolbar__spacer {
@@ -183,13 +186,13 @@ body {
 .format-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   border: 1px solid transparent;
   background: transparent;
-  padding: 0.4rem 0.6rem;
-  border-radius: 6px;
+  padding: 0.6rem 0.85rem;
+  border-radius: 8px;
   color: #3c4043;
-  font-size: 0.85rem;
+  font-size: 1rem;
   cursor: pointer;
 }
 
@@ -202,16 +205,16 @@ body {
   display: flex;
   flex: 1;
   align-items: flex-start;
-  gap: 1.5rem;
-  padding: 1.5rem 1.75rem 2.5rem;
+  gap: 2.5rem;
+  padding: 2rem 2.5rem 3rem;
 }
 
 .doc-wrapper {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  max-width: 900px;
+  gap: 1.5rem;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
@@ -219,35 +222,35 @@ body {
   background: #fff;
   border-radius: 12px;
   border: 1px solid #e8eaed;
-  box-shadow: 0 4px 12px rgba(60, 64, 67, 0.1);
-  padding: 0.85rem 1rem;
+  box-shadow: 0 6px 18px rgba(60, 64, 67, 0.12);
+  padding: 1.2rem 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .suggestion-bar__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   color: #1a73e8;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 1.1rem;
 }
 
 .suggestion-bar__chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .suggestion-chip {
-  padding: 0.45rem 0.85rem;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
   border: 1px solid #c6dafc;
   background: #e8f0fe;
   color: #1a73e8;
-  font-size: 0.85rem;
+  font-size: 1rem;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.2s ease;
 }
@@ -259,13 +262,13 @@ body {
 
 .suggestion-empty {
   color: #5f6368;
-  font-size: 0.85rem;
+  font-size: 1rem;
 }
 
 .support-badge {
-  padding: 0.1rem 0.6rem;
+  padding: 0.15rem 0.7rem;
   border-radius: 999px;
-  font-size: 0.7rem;
+  font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.03em;
 }
@@ -287,19 +290,19 @@ body {
 
 .doc-page-wrapper {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.95));
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.15);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 14px 36px rgba(60, 64, 67, 0.18);
   border: 1px solid #e8eaed;
 }
 
 .doc-page {
-  min-height: 900px;
+  min-height: 1000px;
   background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-  font-size: 1rem;
-  line-height: 1.6;
+  border-radius: 12px;
+  padding: 2rem;
+  font-size: 1.3rem;
+  line-height: 1.85;
   color: #202124;
   outline: none;
   position: relative;
@@ -325,10 +328,10 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.85rem;
+  font-size: 1rem;
   color: #5f6368;
-  padding: 0.5rem 0.75rem;
-  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
   background: #fff;
   border: 1px solid #e8eaed;
 }
@@ -338,16 +341,18 @@ body {
 }
 
 .scaffold-panel {
-  width: 320px;
+  width: 380px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   background: #fff;
-  border-radius: 16px;
-  padding: 1.25rem;
+  border-radius: 20px;
+  padding: 1.5rem;
   border: 1px solid #e8eaed;
-  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.12);
+  box-shadow: 0 14px 36px rgba(60, 64, 67, 0.15);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
 }
 
 .scaffold-panel__header {
@@ -358,37 +363,43 @@ body {
 
 .scaffold-panel__header h2 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 1.25rem;
 }
 
 .scaffold-panel__header p {
-  margin: 0.25rem 0 0;
-  font-size: 0.85rem;
+  margin: 0.4rem 0 0;
+  font-size: 1rem;
   color: #5f6368;
+}
+
+.word-bank-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .word-bank-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .word-bank-tab {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.75rem;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
   border: 1px solid #dadce0;
   background: #f8f9fa;
   color: #3c4043;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   cursor: pointer;
 }
 
 .word-bank-tab__dot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 999px;
 }
 
@@ -401,8 +412,8 @@ body {
 .word-bank-items {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  max-height: 320px;
+  gap: 0.6rem;
+  max-height: 360px;
   overflow: auto;
   padding-right: 0.25rem;
 }
@@ -412,8 +423,8 @@ body {
   flex-direction: column;
   align-items: flex-start;
   border: 1px solid #e8eaed;
-  border-radius: 12px;
-  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
   background: #fff;
   cursor: pointer;
   text-align: left;
@@ -427,49 +438,322 @@ body {
 }
 
 .word-bank-item__text {
-  font-size: 0.95rem;
+  font-size: 1.05rem;
   font-weight: 600;
   color: #1a73e8;
 }
 
 .word-bank-item__hint {
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   color: #5f6368;
-  margin-top: 0.2rem;
+  margin-top: 0.3rem;
 }
 
 .word-bank-empty {
   color: #5f6368;
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   margin: 0;
 }
 
+.suggestion-bar__insights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.suggestion-insight {
+  padding: 0.45rem 0.8rem;
+  border-radius: 12px;
+  background: #f1f3fe;
+  border: 1px solid #d2e3fc;
+  color: #174ea6;
+  font-size: 0.95rem;
+}
+
 .support-card {
-  border-radius: 14px;
+  border-radius: 16px;
   background: linear-gradient(135deg, rgba(26, 115, 232, 0.08), rgba(26, 115, 232, 0.15));
-  padding: 1rem;
+  padding: 1.25rem;
   color: #174ea6;
   border: 1px solid rgba(26, 115, 232, 0.15);
 }
 
 .support-card h3 {
-  margin: 0 0 0.35rem;
-  font-size: 0.95rem;
+  margin: 0 0 0.4rem;
+  font-size: 1.15rem;
 }
 
 .support-card p {
-  margin: 0 0 0.75rem;
-  font-size: 0.85rem;
+  margin: 0 0 0.9rem;
+  font-size: 1rem;
 }
 
 .support-card ul {
   padding-left: 1.1rem;
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
 }
 
 .support-card li {
-  margin-bottom: 0.3rem;
+  margin-bottom: 0.35rem;
+}
+
+.grammar-summary p {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.grammar-focus-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.grammar-focus-list li {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(121, 134, 203, 0.3);
+  border-radius: 12px;
+  padding: 0.8rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.grammar-focus-list__details strong {
+  font-size: 1rem;
+  color: #283593;
+}
+
+.grammar-focus-list__details span {
+  font-size: 0.95rem;
+  color: #37474f;
+}
+
+.grammar-focus-list__details small {
+  font-size: 0.85rem;
+  color: #5f6368;
+}
+
+.grammar-focus-list__examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.grammar-example-chip {
+  border: 1px solid rgba(121, 134, 203, 0.5);
+  background: rgba(121, 134, 203, 0.2);
+  color: #283593;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.grammar-example-chip:hover {
+  background: rgba(121, 134, 203, 0.32);
+}
+
+.grammar-strengths summary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.grammar-strengths ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  font-size: 0.9rem;
+  color: #3c4043;
+}
+
+.spellcheck-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spellcheck-list__item {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 213, 79, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  color: #8d6e00;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.spellcheck-list__item--clear {
+  color: #5f6368;
+  border-color: rgba(255, 213, 79, 0.25);
+}
+
+.spellcheck-clear-message {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.spellcheck-list__details strong {
+  font-size: 1rem;
+}
+
+.spellcheck-list__details span {
+  font-size: 0.95rem;
+  color: #4e342e;
+}
+
+.spellcheck-list__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.spellcheck-suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #fff8e1;
+  border: 1px solid rgba(255, 213, 79, 0.6);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.9rem;
+  color: #8d6e00;
+  cursor: pointer;
+}
+
+.spellcheck-suggestion:hover {
+  background: #ffecb3;
+}
+
+.tts-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.tts-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: #1b5e20;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 3px 8px rgba(27, 94, 32, 0.2);
+}
+
+.tts-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tts-settings {
+  border-top: 1px solid rgba(27, 94, 32, 0.2);
+  padding-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.tts-settings summary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: inherit;
+  margin-bottom: 0.5rem;
+}
+
+.tts-settings__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tts-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  color: #1b5e20;
+}
+
+.tts-field select,
+.tts-field input[type='range'] {
+  font-size: 0.95rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(27, 94, 32, 0.3);
+}
+
+.tts-active-sentence {
+  font-size: 0.95rem;
+  color: #1b5e20;
+  margin: 0.5rem 0 0;
+  background: rgba(129, 199, 132, 0.25);
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+}
+
+.support-card--coach {
+  background: linear-gradient(135deg, rgba(0, 191, 165, 0.12), rgba(0, 191, 165, 0.18));
+  color: #00695c;
+  border-color: rgba(0, 191, 165, 0.2);
+}
+
+.support-card--grammar {
+  background: linear-gradient(135deg, rgba(121, 134, 203, 0.12), rgba(121, 134, 203, 0.2));
+  color: #283593;
+  border-color: rgba(121, 134, 203, 0.3);
+}
+
+.support-card--spelling {
+  background: linear-gradient(135deg, rgba(255, 213, 79, 0.1), rgba(255, 213, 79, 0.2));
+  color: #8d6e00;
+  border-color: rgba(255, 213, 79, 0.35);
+}
+
+.support-card--tts {
+  background: linear-gradient(135deg, rgba(129, 199, 132, 0.12), rgba(129, 199, 132, 0.2));
+  color: #1b5e20;
+  border-color: rgba(129, 199, 132, 0.3);
+}
+
+.support-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.support-card__header-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.support-card__message {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: inherit;
 }
 
 @media (max-width: 1200px) {
@@ -479,6 +763,8 @@ body {
 
   .scaffold-panel {
     width: 100%;
+    max-height: none;
+    overflow: visible;
   }
 }
 
@@ -490,7 +776,7 @@ body {
 
   .doc-layout {
     padding: 1rem;
-  }
+    }
 
   .doc-wrapper {
     width: 100%;

--- a/src/components/GrammarCoach.jsx
+++ b/src/components/GrammarCoach.jsx
@@ -1,0 +1,92 @@
+import PropTypes from 'prop-types';
+import { Lightbulb, ShieldCheck } from 'lucide-react';
+
+const GrammarCoach = ({ analysis, onExampleSelect, hasText }) => {
+  const needsFocus = hasText ? analysis.filter((item) => !item.met) : [];
+  const strengths = hasText ? analysis.filter((item) => item.met) : [];
+
+  return (
+    <section className="support-card support-card--grammar">
+      <div className="support-card__header">
+        <div className="support-card__header-icon" aria-hidden="true">
+          <Lightbulb size={20} />
+        </div>
+        <div>
+          <h3>UK grammar check</h3>
+          <p>Aligned with the national curriculum grammar appendix.</p>
+        </div>
+      </div>
+
+      <div className="grammar-summary">
+        <p>
+          {hasText ? (
+            needsFocus.length
+              ? `${needsFocus.length} focus ${needsFocus.length === 1 ? 'area' : 'areas'} to strengthen.`
+              : 'Great! All tracked grammar targets are present.'
+          ) : (
+            'Start typing to see the grammar targets update here.'
+          )}
+        </p>
+      </div>
+
+      {needsFocus.length ? (
+        <ul className="grammar-focus-list">
+          {needsFocus.map((item) => (
+            <li key={item.id}>
+              <div className="grammar-focus-list__details">
+                <strong>{item.label}</strong>
+                <span>{item.tip}</span>
+                <small>{item.ncReference} – {item.stage}</small>
+              </div>
+              {item.examples?.length ? (
+                <div className="grammar-focus-list__examples">
+                  {item.examples.map((example) => (
+                    <button
+                      key={example}
+                      type="button"
+                      className="grammar-example-chip"
+                      onClick={() => onExampleSelect?.(example)}
+                    >
+                      {example}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {strengths.length ? (
+        <details className="grammar-strengths">
+          <summary>
+            <ShieldCheck size={16} aria-hidden="true" /> Secure features
+          </summary>
+          <ul>
+            {strengths.map((item) => (
+              <li key={item.id}>{item.label}</li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </section>
+  );
+};
+
+GrammarCoach.propTypes = {
+  analysis: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      met: PropTypes.bool.isRequired,
+      tip: PropTypes.string.isRequired,
+      stage: PropTypes.string.isRequired,
+      examples: PropTypes.arrayOf(PropTypes.string),
+      ncReference: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  onExampleSelect: PropTypes.func,
+  hasText: PropTypes.bool
+};
+
+export default GrammarCoach;

--- a/src/components/SpeechControls.jsx
+++ b/src/components/SpeechControls.jsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Volume2, VolumeX, PauseCircle, PlayCircle, RotateCw, Settings } from 'lucide-react';
+import { useSpeechSynthesis } from '../hooks/useSpeechSynthesis';
+
+const formatVoiceLabel = (voice) => {
+  if (!voice) {
+    return '';
+  }
+  const lang = voice.lang ? voice.lang.replace('_', '-') : '';
+  return `${voice.name}${lang ? ` (${lang})` : ''}`;
+};
+
+const SpeechControls = ({ text, onSentenceFocus }) => {
+  const {
+    voices,
+    voiceURI,
+    setVoiceURI,
+    rate,
+    setRate,
+    pitch,
+    setPitch,
+    speak,
+    stop,
+    pause,
+    resume,
+    isSpeaking,
+    isPaused,
+    currentSentenceIndex,
+    isSupported
+  } = useSpeechSynthesis();
+
+  const [activeSentence, setActiveSentence] = useState('');
+
+  const sortedVoices = useMemo(() => {
+    return voices
+      .slice()
+      .sort((a, b) => {
+        const aUK = a.lang?.toLowerCase().startsWith('en-gb') ? 0 : 1;
+        const bUK = b.lang?.toLowerCase().startsWith('en-gb') ? 0 : 1;
+        if (aUK !== bUK) {
+          return aUK - bUK;
+        }
+        return a.name.localeCompare(b.name);
+      });
+  }, [voices]);
+
+  const handleSpeak = () => {
+    if (!text?.trim()) {
+      return;
+    }
+    speak(text, {
+      onSentenceStart: (index, sentence) => {
+        setActiveSentence(sentence ?? '');
+        onSentenceFocus?.(index, sentence);
+      }
+    });
+  };
+
+  const handleStop = () => {
+    stop();
+    setActiveSentence('');
+    onSentenceFocus?.(null, '');
+  };
+
+  const handlePauseResume = () => {
+    if (isPaused) {
+      resume();
+    } else {
+      pause();
+    }
+  };
+
+  return (
+    <section className="support-card support-card--tts">
+      <div className="support-card__header">
+        <div className="support-card__header-icon" aria-hidden="true">
+          <Volume2 size={20} />
+        </div>
+        <div>
+          <h3>Read it aloud</h3>
+          <p>High quality speech using your device’s voices.</p>
+        </div>
+      </div>
+
+      {!isSupported ? (
+        <p className="support-card__message">
+          <VolumeX size={16} aria-hidden="true" /> Text-to-speech is not supported in this browser.
+        </p>
+      ) : (
+        <>
+          <div className="tts-controls">
+            <button
+              type="button"
+              className="tts-button"
+              onClick={handleSpeak}
+              disabled={!text?.trim()}
+            >
+              <PlayCircle size={20} />
+              Play document
+            </button>
+            <button
+              type="button"
+              className="tts-button"
+              onClick={handlePauseResume}
+              disabled={!isSpeaking}
+            >
+              <PauseCircle size={20} />
+              {isPaused ? 'Resume' : 'Pause'}
+            </button>
+            <button type="button" className="tts-button" onClick={handleStop} disabled={!isSpeaking}>
+              <RotateCw size={20} />
+              Stop
+            </button>
+          </div>
+
+          <details className="tts-settings">
+            <summary>
+              <Settings size={16} aria-hidden="true" /> Voice settings
+            </summary>
+            <div className="tts-settings__body">
+              <label className="tts-field">
+                <span>Voice</span>
+                <select
+                  value={voiceURI}
+                  onChange={(event) => setVoiceURI(event.target.value)}
+                  aria-label="Select speaking voice"
+                  disabled={!sortedVoices.length}
+                >
+                  {sortedVoices.length ? (
+                    sortedVoices.map((voice) => (
+                      <option key={voice.voiceURI} value={voice.voiceURI}>
+                        {formatVoiceLabel(voice)}
+                      </option>
+                    ))
+                  ) : (
+                    <option value="">No voices available</option>
+                  )}
+                </select>
+              </label>
+              <label className="tts-field">
+                <span>Speed</span>
+                <input
+                  type="range"
+                  min="0.6"
+                  max="1.4"
+                  step="0.05"
+                  value={rate}
+                  onChange={(event) => setRate(Number.parseFloat(event.target.value))}
+                  aria-label="Speech speed"
+                />
+              </label>
+              <label className="tts-field">
+                <span>Pitch</span>
+                <input
+                  type="range"
+                  min="0.7"
+                  max="1.3"
+                  step="0.05"
+                  value={pitch}
+                  onChange={(event) => setPitch(Number.parseFloat(event.target.value))}
+                  aria-label="Speech pitch"
+                />
+              </label>
+            </div>
+          </details>
+
+          {isSpeaking && (
+            <p className="tts-active-sentence">
+              Reading sentence {currentSentenceIndex != null ? currentSentenceIndex + 1 : ''}: {activeSentence}
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+SpeechControls.propTypes = {
+  text: PropTypes.string.isRequired,
+  onSentenceFocus: PropTypes.func
+};
+
+export default SpeechControls;

--- a/src/components/SpellCheckPanel.jsx
+++ b/src/components/SpellCheckPanel.jsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { CheckCircle2, Sparkles, Wand2 } from 'lucide-react';
+import {
+  initializeSpellChecker,
+  checkSpelling,
+  getSuggestions
+} from '../spellChecker';
+
+const wordRegex = /[\p{L}'’-]+/gu;
+
+const makeIssueId = (issue) =>
+  `${issue.type}-${issue.word ?? issue.message}-${issue.contextIndex ?? 0}`;
+
+const SpellCheckPanel = ({ plainText, onApplySuggestion }) => {
+  const [ready, setReady] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [issues, setIssues] = useState([]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    initializeSpellChecker()
+      .then(() => {
+        if (active) {
+          setReady(true);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setReady(false);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!ready) {
+      return;
+    }
+    const text = plainText ?? '';
+    if (!text.trim()) {
+      setIssues([]);
+      return;
+    }
+
+    const matches = Array.from(text.matchAll(wordRegex));
+    const uniqueWords = new Map();
+
+    matches.forEach((match) => {
+      const [word] = match;
+      const index = match.index ?? 0;
+      const lower = word.toLowerCase();
+      if (!uniqueWords.has(lower)) {
+        uniqueWords.set(lower, { original: word, index });
+      }
+    });
+
+    const detectedIssues = [];
+
+    uniqueWords.forEach(({ original, index }) => {
+      if (!checkSpelling(original)) {
+        const suggestions = getSuggestions(original).slice(0, 4);
+        detectedIssues.push({
+          type: 'spelling',
+          word: original,
+          message: `Check the spelling of "${original}"`,
+          suggestions,
+          contextIndex: index
+        });
+      }
+    });
+
+    for (let i = 1; i < matches.length; i += 1) {
+      const current = matches[i][0];
+      const previous = matches[i - 1][0];
+      if (current && previous && current.toLowerCase() === previous.toLowerCase()) {
+        detectedIssues.push({
+          type: 'repetition',
+          word: current,
+          message: `"${current}" is repeated. Decide if you need both instances.`,
+          contextIndex: matches[i].index ?? 0
+        });
+      }
+    }
+
+    if (/\s{2,}/.test(text)) {
+      detectedIssues.push({
+        type: 'spacing',
+        message: 'There are extra spaces. Replace double spaces with single spaces.'
+      });
+    }
+
+    setIssues(detectedIssues);
+  }, [plainText, ready]);
+
+  const summary = useMemo(() => {
+    if (!ready) {
+      return 'Preparing UK dictionary…';
+    }
+    if (!issues.length) {
+      return 'No spelling concerns found.';
+    }
+    return `${issues.length} ${issues.length === 1 ? 'issue' : 'issues'} to review.`;
+  }, [issues.length, ready]);
+
+  return (
+    <section className="support-card support-card--spelling">
+      <div className="support-card__header">
+        <div className="support-card__header-icon" aria-hidden="true">
+          <Sparkles size={20} />
+        </div>
+        <div>
+          <h3>Spell smart</h3>
+          <p>UK English dictionary with child-friendly suggestions.</p>
+        </div>
+      </div>
+
+      <p className="support-card__message">{summary}</p>
+
+      {loading ? (
+        <p className="support-card__message">Loading dictionary…</p>
+      ) : (
+        <ul className="spellcheck-list">
+          {issues.length === 0 ? (
+            <li className="spellcheck-list__item spellcheck-list__item--clear">
+              <span className="spellcheck-clear-message">
+                <CheckCircle2 size={18} aria-hidden="true" /> Everything looks accurate.
+              </span>
+            </li>
+          ) : (
+            issues.map((issue) => (
+              <li key={makeIssueId(issue)} className="spellcheck-list__item">
+                <div className="spellcheck-list__details">
+                  <strong>{issue.word ?? issue.type}</strong>
+                  <span>{issue.message}</span>
+                </div>
+                {issue.type === 'spelling' && issue.suggestions?.length ? (
+                  <div className="spellcheck-list__suggestions">
+                    {issue.suggestions.map((suggestion) => (
+                      <button
+                        key={suggestion}
+                        type="button"
+                        className="spellcheck-suggestion"
+                        onClick={() =>
+                          onApplySuggestion({
+                            type: 'spelling',
+                            original: issue.word,
+                            replacement: suggestion,
+                            contextIndex: issue.contextIndex
+                          })
+                        }
+                      >
+                        <Wand2 size={14} aria-hidden="true" /> {suggestion}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                {issue.type === 'spacing' ? (
+                  <button
+                    type="button"
+                    className="spellcheck-suggestion"
+                    onClick={() =>
+                      onApplySuggestion({ type: 'spacing', original: '  ', replacement: ' ' })
+                    }
+                  >
+                    <Wand2 size={14} aria-hidden="true" /> Fix spacing
+                  </button>
+                ) : null}
+                {issue.type === 'repetition' ? (
+                  <button
+                    type="button"
+                    className="spellcheck-suggestion"
+                    onClick={() =>
+                      onApplySuggestion({
+                        type: 'repetition',
+                        original: issue.word,
+                        replacement: issue.word,
+                        contextIndex: issue.contextIndex
+                      })
+                    }
+                  >
+                    <Wand2 size={14} aria-hidden="true" /> Remove duplicate
+                  </button>
+                ) : null}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+SpellCheckPanel.propTypes = {
+  plainText: PropTypes.string.isRequired,
+  onApplySuggestion: PropTypes.func.isRequired
+};
+
+export default SpellCheckPanel;

--- a/src/data/ukGrammarAppendix.js
+++ b/src/data/ukGrammarAppendix.js
@@ -1,0 +1,180 @@
+export const grammarObjectives = [
+  {
+    id: 'capitalLetters',
+    label: 'Capital letters for sentences',
+    area: 'Sentence punctuation',
+    stage: 'KS1',
+    description:
+      'Every sentence in the national curriculum should begin with a capital letter.',
+    tip: 'Check the opening letter of each sentence and make it uppercase if needed.',
+    ncReference: 'NC English Appendix 2 – Sentence punctuation',
+    examples: ['The', 'Yesterday', 'After']
+  },
+  {
+    id: 'fullStops',
+    label: 'Full stops to end sentences',
+    area: 'Sentence punctuation',
+    stage: 'KS1',
+    description:
+      'Statements should finish with a full stop so the reader knows the idea has ended.',
+    tip: 'Read your sentence aloud and add a full stop when the idea finishes.',
+    ncReference: 'NC English Appendix 2 – Sentence punctuation',
+    examples: ['.']
+  },
+  {
+    id: 'questionMarks',
+    label: 'Question marks for questions',
+    area: 'Sentence punctuation',
+    stage: 'KS1',
+    description: 'Questions need a question mark to show the reader to use a rising tone.',
+    tip: 'If you asked something, finish the sentence with a question mark.',
+    ncReference: 'NC English Appendix 2 – Sentence punctuation',
+    examples: ['?']
+  },
+  {
+    id: 'exclamationMarks',
+    label: 'Exclamation marks for strong feelings',
+    area: 'Sentence punctuation',
+    stage: 'KS1',
+    description:
+      'Use an exclamation mark for commands or sentences that show strong emotion.',
+    tip: 'Add an exclamation mark when you write a command or a strong feeling.',
+    ncReference: 'NC English Appendix 2 – Sentence punctuation',
+    examples: ['!']
+  },
+  {
+    id: 'conjunctions',
+    label: 'Co-ordinating conjunctions',
+    area: 'Text cohesion',
+    stage: 'KS1',
+    description:
+      'Words such as "and", "but" and "so" join ideas to build compound sentences.',
+    tip: 'Join short sentences using and, but, or so to make the writing flow.',
+    ncReference: 'NC English Appendix 2 – Co-ordination',
+    examples: ['and', 'but', 'so', 'or']
+  },
+  {
+    id: 'subordinateConjunctions',
+    label: 'Subordinating conjunctions',
+    area: 'Text cohesion',
+    stage: 'Lower KS2',
+    description:
+      'Words like "because" and "when" introduce subordinate clauses to explain more.',
+    tip: 'Add clauses with because, when, if or that to explain or add detail.',
+    ncReference: 'NC English Appendix 2 – Subordination',
+    examples: ['because', 'when', 'if', 'that', 'although', 'since']
+  },
+  {
+    id: 'nounPhrases',
+    label: 'Expanded noun phrases',
+    area: 'Word classes',
+    stage: 'KS1',
+    description:
+      'Expanded noun phrases use adjectives to give more information about a noun.',
+    tip: 'Add a describing word before the noun, e.g. "the curious scientist".',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['bright', 'curious', 'brave']
+  },
+  {
+    id: 'adjectives',
+    label: 'Describing adjectives',
+    area: 'Word classes',
+    stage: 'KS1',
+    description:
+      'Adjectives describe nouns and help the reader picture the idea clearly.',
+    tip: 'Use adjectives like colourful, gentle or enormous to add detail.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['colourful', 'gentle', 'enormous', 'sparkling']
+  },
+  {
+    id: 'adverbs',
+    label: 'Adverbs for how and when',
+    area: 'Word classes',
+    stage: 'Lower KS2',
+    description:
+      'Adverbs describe how, when or where something happens.',
+    tip: 'Try adding adverbs like carefully, quickly or later.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['carefully', 'quickly', 'suddenly', 'later']
+  },
+  {
+    id: 'verbs',
+    label: 'Powerful verbs',
+    area: 'Word classes',
+    stage: 'KS1',
+    description:
+      'Precise verbs keep the action clear, such as sprinted, whispered or investigate.',
+    tip: 'Swap common verbs for more exact ones from the action bank.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['investigate', 'discover', 'observed']
+  },
+  {
+    id: 'progressiveVerbs',
+    label: 'Progressive verb forms',
+    area: 'Word classes',
+    stage: 'Lower KS2',
+    description:
+      'The progressive form (was walking, is jumping) shows actions in progress.',
+    tip: 'Use "is" or "was" with a verb ending in -ing to show ongoing action.',
+    ncReference: 'NC English Appendix 2 – Verb',
+    examples: ['is exploring', 'was running']
+  },
+  {
+    id: 'pronouns',
+    label: 'Personal and possessive pronouns',
+    area: 'Word classes',
+    stage: 'Lower KS2',
+    description:
+      'Pronouns replace nouns to avoid repetition and improve cohesion.',
+    tip: 'Switch a repeated noun for pronouns like they, she, him or their.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['they', 'she', 'their']
+  },
+  {
+    id: 'determiners',
+    label: 'Determiners before nouns',
+    area: 'Word classes',
+    stage: 'KS1',
+    description: 'Determiners introduce nouns so the reader knows which one you mean.',
+    tip: 'Use words like the, a, this or those before nouns to add clarity.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['the', 'a', 'this', 'those']
+  },
+  {
+    id: 'prepositions',
+    label: 'Prepositions for where and when',
+    area: 'Word classes',
+    stage: 'Lower KS2',
+    description:
+      'Prepositions like under, before or during link ideas with place or time.',
+    tip: 'Add a preposition to show where or when something happens.',
+    ncReference: 'NC English Appendix 2 – Word',
+    examples: ['before', 'during', 'under', 'beyond']
+  },
+  {
+    id: 'commasInLists',
+    label: 'Commas in a list',
+    area: 'Punctuation',
+    stage: 'Lower KS2',
+    description:
+      'Use commas to separate items in a list before the final and or or.',
+    tip: 'Try writing three ideas in a row separated with commas.',
+    ncReference: 'NC English Appendix 2 – Punctuation',
+    examples: ['red, blue and green']
+  },
+  {
+    id: 'apostrophes',
+    label: 'Apostrophes for possession or contraction',
+    area: 'Punctuation',
+    stage: 'KS1 and KS2',
+    description:
+      'Use apostrophes for missing letters (don\'t) and for showing something belongs to someone.',
+    tip: 'Check if a contraction or possessive needs an apostrophe.',
+    ncReference: 'NC English Appendix 2 – Punctuation',
+    examples: ["don't", "the scientist's notes"]
+  }
+];
+
+export const grammarObjectiveLookup = new Map(
+  grammarObjectives.map((objective) => [objective.id, objective])
+);

--- a/src/hooks/usePredictiveSuggestions.js
+++ b/src/hooks/usePredictiveSuggestions.js
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  determiners,
+  linkingVerbs,
+  modalHelpers,
+  pronounFriendlyVerbs,
+  pronouns,
+  supportiveSentenceFrames,
+  timeMarkers
+} from '../data/ealWordBank';
+import { grammarObjectiveLookup } from '../data/ukGrammarAppendix';
+import { fetchNextWords, fetchSuggestions } from '../utils/dictionary';
+
+const normalise = (value = '') => value.toLowerCase().trim();
+
+const formatForSentenceStart = (suggestion) => {
+  if (!suggestion) {
+    return suggestion;
+  }
+  const trimmed = suggestion.trimStart();
+  if (!trimmed) {
+    return suggestion;
+  }
+  const firstChar = trimmed[0];
+  if (!/[a-zA-Z]/.test(firstChar)) {
+    return suggestion;
+  }
+  return `${firstChar.toUpperCase()}${trimmed.slice(1)}`;
+};
+
+const gatherCategoryItems = (categoryLookup, categoryId) =>
+  categoryLookup.get(categoryId)?.items.map((item) => item.text) ?? [];
+
+export const usePredictiveSuggestions = ({
+  caretContext,
+  categoryLookup,
+  uniqueWordList,
+  grammarAnalysis
+}) => {
+  const prefix = caretContext.prefix ?? '';
+  const previousWord = caretContext.previousWord ?? '';
+  const textBeforeCaret = caretContext.textBeforeCaret ?? '';
+
+  const isNewSentence = !textBeforeCaret || /[.!?]\s*$/.test(textBeforeCaret);
+
+  const missingFeatureIds = useMemo(
+    () =>
+      new Set(
+        (grammarAnalysis ?? [])
+          .filter((item) => !item.met)
+          .map((item) => item.id)
+      ),
+    [grammarAnalysis]
+  );
+
+  const [asyncSuggestions, setAsyncSuggestions] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const trimmedPrefix = normalise(prefix);
+    const trimmedPrevious = normalise(previousWord);
+
+    if (!trimmedPrefix && !trimmedPrevious) {
+      setAsyncSuggestions([]);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const timer = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const tasks = [];
+        if (trimmedPrefix.length >= 2) {
+          tasks.push(fetchSuggestions(trimmedPrefix));
+        }
+        if (trimmedPrevious) {
+          tasks.push(fetchNextWords(trimmedPrevious));
+        }
+        const results = await Promise.all(tasks);
+        const combined = results.flat();
+        if (!cancelled) {
+          setAsyncSuggestions(combined);
+        }
+      } catch {
+        if (!cancelled) {
+          setAsyncSuggestions([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }, 180);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [prefix, previousWord]);
+
+  const synchronousSuggestions = useMemo(() => {
+    const candidates = new Set();
+    const lowerPrefix = normalise(prefix);
+    const lowerPrevious = normalise(previousWord);
+
+    const addCandidate = (suggestion, { capitaliseForSentence = false } = {}) => {
+      if (!suggestion) {
+        return;
+      }
+      const trimmed = suggestion.trim();
+      if (!trimmed) {
+        return;
+      }
+      const formatted = capitaliseForSentence
+        ? formatForSentenceStart(trimmed)
+        : trimmed;
+      candidates.add(formatted);
+    };
+
+    if (lowerPrefix) {
+      uniqueWordList
+        .filter((word) => {
+          const normalisedWord = normalise(word);
+          return normalisedWord.startsWith(lowerPrefix) && normalisedWord !== lowerPrefix;
+        })
+        .slice(0, 6)
+        .forEach((word) => addCandidate(word, { capitaliseForSentence: isNewSentence }));
+    }
+
+    if (isNewSentence) {
+      supportiveSentenceFrames.forEach((frame) =>
+        addCandidate(frame, { capitaliseForSentence: true })
+      );
+    } else if (pronouns.includes(lowerPrevious)) {
+      pronounFriendlyVerbs.forEach((verb) => addCandidate(verb));
+    } else if (determiners.includes(lowerPrevious)) {
+      gatherCategoryItems(categoryLookup, 'descriptions').forEach((item) => addCandidate(item));
+      gatherCategoryItems(categoryLookup, 'people').forEach((item) => addCandidate(item));
+    } else if (linkingVerbs.includes(lowerPrevious)) {
+      gatherCategoryItems(categoryLookup, 'descriptions').forEach((item) => addCandidate(item));
+    } else if (timeMarkers.includes(lowerPrevious)) {
+      gatherCategoryItems(categoryLookup, 'actions').forEach((item) => addCandidate(item));
+    } else if (modalHelpers.includes(lowerPrevious)) {
+      gatherCategoryItems(categoryLookup, 'actions').forEach((item) => addCandidate(item));
+    }
+
+    if (missingFeatureIds.has('conjunctions')) {
+      gatherCategoryItems(categoryLookup, 'connectors').forEach((item) => addCandidate(item));
+    }
+    if (missingFeatureIds.has('subordinateConjunctions')) {
+      const examples = grammarObjectiveLookup.get('subordinateConjunctions')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example));
+    }
+    if (missingFeatureIds.has('nounPhrases') || missingFeatureIds.has('adjectives')) {
+      gatherCategoryItems(categoryLookup, 'descriptions').forEach((item) =>
+        addCandidate(item, { capitaliseForSentence: isNewSentence })
+      );
+    }
+    if (missingFeatureIds.has('adverbs')) {
+      const examples = grammarObjectiveLookup.get('adverbs')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example));
+    }
+    if (missingFeatureIds.has('prepositions')) {
+      const examples = grammarObjectiveLookup.get('prepositions')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example));
+    }
+    if (missingFeatureIds.has('capitalLetters') && isNewSentence) {
+      const examples = grammarObjectiveLookup.get('capitalLetters')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example, { capitaliseForSentence: true }));
+    }
+    if (missingFeatureIds.has('verbs')) {
+      gatherCategoryItems(categoryLookup, 'actions').forEach((item) => addCandidate(item));
+    }
+    if (missingFeatureIds.has('pronouns')) {
+      const examples = grammarObjectiveLookup.get('pronouns')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example));
+    }
+    if (missingFeatureIds.has('determiners')) {
+      const examples = grammarObjectiveLookup.get('determiners')?.examples ?? [];
+      examples.forEach((example) => addCandidate(example));
+    }
+
+    if (!lowerPrefix && !lowerPrevious && isNewSentence) {
+      const capitalExamples = grammarObjectiveLookup.get('capitalLetters')?.examples ?? [];
+      capitalExamples.forEach((example) => addCandidate(example, { capitaliseForSentence: true }));
+    }
+
+    return Array.from(candidates);
+  }, [
+    categoryLookup,
+    uniqueWordList,
+    prefix,
+    previousWord,
+    isNewSentence,
+    missingFeatureIds
+  ]);
+
+  const insights = useMemo(() => {
+    const unmet = (grammarAnalysis ?? []).filter((item) => !item.met);
+    return unmet.slice(0, 3).map((item) => item.tip);
+  }, [grammarAnalysis]);
+
+  const suggestions = useMemo(() => {
+    const seen = new Set();
+    const ordered = [];
+
+    const register = (suggestion) => {
+      if (!suggestion) {
+        return;
+      }
+      const key = normalise(suggestion);
+      if (!key) {
+        return;
+      }
+      if (!seen.has(key)) {
+        seen.add(key);
+        ordered.push(suggestion);
+      }
+    };
+
+    synchronousSuggestions.forEach(register);
+    asyncSuggestions.forEach((suggestion) => register(suggestion));
+
+    return ordered.slice(0, 10);
+  }, [asyncSuggestions, synchronousSuggestions]);
+
+  return { suggestions, insights, isLoading };
+};

--- a/src/hooks/useSpeechSynthesis.js
+++ b/src/hooks/useSpeechSynthesis.js
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const splitIntoSentences = (text) =>
+  text
+    .match(/[^.!?]+[.!?]*/g)
+    ?.map((part) => part.trim())
+    .filter(Boolean) ?? [text.trim()].filter(Boolean);
+
+export const useSpeechSynthesis = () => {
+  const [voices, setVoices] = useState([]);
+  const [voiceURI, setVoiceURI] = useState('');
+  const [rate, setRate] = useState(0.95);
+  const [pitch, setPitch] = useState(1);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [currentSentenceIndex, setCurrentSentenceIndex] = useState(null);
+  const [isSupported, setIsSupported] = useState(false);
+  const defaultVoiceSetRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
+      setIsSupported(false);
+      return;
+    }
+
+    setIsSupported(true);
+
+    const updateVoices = () => {
+      const available = window.speechSynthesis.getVoices();
+      setVoices(available);
+      if (!defaultVoiceSetRef.current && available.length) {
+        const preferred =
+          available.find((voice) => voice.lang?.toLowerCase().startsWith('en-gb')) ??
+          available.find((voice) => voice.lang?.toLowerCase().startsWith('en')) ??
+          available[0];
+        if (preferred) {
+          setVoiceURI(preferred.voiceURI);
+          defaultVoiceSetRef.current = true;
+        }
+      }
+    };
+
+    updateVoices();
+    window.speechSynthesis.addEventListener?.('voiceschanged', updateVoices);
+
+    return () => {
+      window.speechSynthesis.removeEventListener?.('voiceschanged', updateVoices);
+    };
+  }, []);
+
+  const selectedVoice = useMemo(() => {
+    if (!voiceURI) {
+      return null;
+    }
+    return voices.find((voice) => voice.voiceURI === voiceURI) ?? null;
+  }, [voiceURI, voices]);
+
+  const stop = useCallback(() => {
+    if (!isSupported) {
+      return;
+    }
+    window.speechSynthesis.cancel();
+    setIsSpeaking(false);
+    setIsPaused(false);
+    setCurrentSentenceIndex(null);
+  }, [isSupported]);
+
+  const speak = useCallback(
+    (text, { onSentenceStart } = {}) => {
+      if (!isSupported) {
+        return;
+      }
+      const trimmed = text?.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      stop();
+
+      const sentences = splitIntoSentences(trimmed);
+      if (!sentences.length) {
+        return;
+      }
+
+      const voiceToUse = selectedVoice ?? voices.find((voice) => voice.lang?.startsWith('en')) ?? null;
+
+      sentences.forEach((sentence, index) => {
+        const utterance = new SpeechSynthesisUtterance(sentence);
+        if (voiceToUse) {
+          utterance.voice = voiceToUse;
+        }
+        utterance.rate = rate;
+        utterance.pitch = pitch;
+        utterance.onstart = () => {
+          setIsSpeaking(true);
+          setIsPaused(false);
+          setCurrentSentenceIndex(index);
+          onSentenceStart?.(index, sentence);
+        };
+        utterance.onend = () => {
+          if (index === sentences.length - 1) {
+            setIsSpeaking(false);
+            setCurrentSentenceIndex(null);
+            onSentenceStart?.(null, '');
+          }
+        };
+        window.speechSynthesis.speak(utterance);
+      });
+    },
+    [isSupported, rate, pitch, selectedVoice, stop, voices]
+  );
+
+  const pause = useCallback(() => {
+    if (!isSupported) {
+      return;
+    }
+    window.speechSynthesis.pause();
+    setIsPaused(true);
+  }, [isSupported]);
+
+  const resume = useCallback(() => {
+    if (!isSupported) {
+      return;
+    }
+    window.speechSynthesis.resume();
+    setIsPaused(false);
+  }, [isSupported]);
+
+  return {
+    voices,
+    voiceURI,
+    setVoiceURI,
+    rate,
+    setRate,
+    pitch,
+    setPitch,
+    speak,
+    stop,
+    pause,
+    resume,
+    isSpeaking,
+    isPaused,
+    currentSentenceIndex,
+    isSupported
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -3,12 +3,16 @@
 @tailwind utilities;
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
   font-weight: 400;
+  font-size: 18px;
+  background-color: #f1f3f4;
+  color: #202124;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: #f1f3f4;
 }

--- a/src/spellChecker.js
+++ b/src/spellChecker.js
@@ -1,34 +1,113 @@
 // src/spellChecker.js
 
 import nspell from 'nspell';
+import {
+  flattenWordBank,
+  highFrequencyWords,
+  supportiveSentenceFrames,
+  wordBankCategories
+} from './data/ealWordBank';
+import { grammarObjectives } from './data/ukGrammarAppendix';
 import { filterChildFriendly } from './utils/filterSuggestions.js';
 
 let spell;
 
-export const initializeSpellChecker = async () => {
-  if (!spell) {
-    const [aff, dic] = await Promise.all([
-      fetch('https://cdn.jsdelivr.net/npm/dictionary-en/index.aff').then((r) =>
-        r.text()
-      ),
-      fetch('https://cdn.jsdelivr.net/npm/dictionary-en/index.dic').then((r) =>
-        r.text()
-      )
-    ]);
-    spell = nspell(aff, dic);
+const dictionarySources = [
+  {
+    aff: 'https://cdn.jsdelivr.net/npm/dictionary-en-gb/index.aff',
+    dic: 'https://cdn.jsdelivr.net/npm/dictionary-en-gb/index.dic'
+  },
+  {
+    aff: 'https://cdn.jsdelivr.net/npm/dictionary-en/index.aff',
+    dic: 'https://cdn.jsdelivr.net/npm/dictionary-en/index.dic'
   }
+];
+
+const sanitiseForLexicon = (word) => word.replace(/[^a-z'-]/gi, '').toLowerCase();
+
+const extendDictionaryWithCurriculumWords = (instance) => {
+  if (!instance) {
+    return;
+  }
+  const customWords = new Set();
+  flattenWordBank(wordBankCategories, 'advanced').forEach((phrase) => {
+    phrase
+      .split(/\s+/)
+      .map(sanitiseForLexicon)
+      .filter(Boolean)
+      .forEach((word) => customWords.add(word));
+  });
+  supportiveSentenceFrames.forEach((frame) => {
+    frame
+      .split(/\s+/)
+      .map(sanitiseForLexicon)
+      .filter(Boolean)
+      .forEach((word) => customWords.add(word));
+  });
+  highFrequencyWords
+    .map(sanitiseForLexicon)
+    .filter(Boolean)
+    .forEach((word) => customWords.add(word));
+  grammarObjectives.forEach((objective) => {
+    (objective.examples ?? []).forEach((example) => {
+      example
+        .split(/\s+/)
+        .map(sanitiseForLexicon)
+        .filter(Boolean)
+        .forEach((word) => customWords.add(word));
+    });
+  });
+
+  customWords.forEach((word) => {
+    try {
+      instance.add(word);
+    } catch {
+      // Ignore words that cannot be added to the lexicon
+    }
+  });
+};
+
+export const initializeSpellChecker = async () => {
+  if (spell) {
+    return spell;
+  }
+
+  for (const source of dictionarySources) {
+    try {
+      const [aff, dic] = await Promise.all([
+        fetch(source.aff).then((response) => response.text()),
+        fetch(source.dic).then((response) => response.text())
+      ]);
+      spell = nspell(aff, dic);
+      extendDictionaryWithCurriculumWords(spell);
+      break;
+    } catch {
+      // try next dictionary source
+    }
+  }
+
+  if (!spell) {
+    throw new Error('Unable to load dictionary data');
+  }
+
   return spell;
 };
 
 export const checkSpelling = (word) => {
   if (!spell) return true; // Assume correct if spell checker not initialized
-  const sanitized = word.toLowerCase().replace(/[^a-z']/g, '');
-  return spell.correct(sanitized);
+  const sanitised = sanitiseForLexicon(word);
+  if (!sanitised) {
+    return true;
+  }
+  return spell.correct(sanitised);
 };
 
 export const getSuggestions = (word) => {
   if (!spell) return [];
-  const sanitized = word.toLowerCase().replace(/[^a-z']/g, '');
-  const suggestions = spell.suggest(sanitized);
+  const sanitised = sanitiseForLexicon(word);
+  if (!sanitised) {
+    return [];
+  }
+  const suggestions = spell.suggest(sanitised);
   return filterChildFriendly(suggestions);
 };

--- a/src/utils/grammarAnalysis.js
+++ b/src/utils/grammarAnalysis.js
@@ -1,0 +1,100 @@
+import nlp from 'compromise';
+import { determiners, pronouns } from '../data/ealWordBank';
+import { grammarObjectives } from '../data/ukGrammarAppendix';
+
+const coordinatingConjunctions = ['and', 'but', 'or', 'so', 'yet'];
+const subordinatingConjunctions = [
+  'because',
+  'when',
+  'if',
+  'that',
+  'although',
+  'since',
+  'after',
+  'before',
+  'while',
+  'until',
+  'unless'
+];
+const prepositions = [
+  'before',
+  'after',
+  'under',
+  'over',
+  'into',
+  'onto',
+  'during',
+  'beyond',
+  'inside',
+  'outside',
+  'between',
+  'across',
+  'through'
+];
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const sentenceSplitter = (text) =>
+  text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+
+const detectors = {
+  capitalLetters: ({ sentences }) =>
+    sentences.length > 0 &&
+    sentences.every((sentence) => {
+      const firstChar = sentence.trim()[0];
+      if (!firstChar) {
+        return true;
+      }
+      return firstChar === firstChar.toUpperCase() && /[A-Z]/.test(firstChar);
+    }),
+  fullStops: ({ sentences }) =>
+    sentences.length > 0 &&
+    sentences.every((sentence) => /[.!?]$/.test(sentence)),
+  questionMarks: ({ text }) => /\?/u.test(text),
+  exclamationMarks: ({ text }) => /!/u.test(text),
+  conjunctions: ({ text }) =>
+    new RegExp(`\\b(${coordinatingConjunctions.map(escapeRegex).join('|')})\\b`, 'i').test(
+      text
+    ),
+  subordinateConjunctions: ({ text }) =>
+    new RegExp(`\\b(${subordinatingConjunctions.map(escapeRegex).join('|')})\\b`, 'i').test(
+      text
+    ),
+  nounPhrases: ({ doc }) => doc?.match('#Determiner? #Adjective+ #Noun').found ?? false,
+  adjectives: ({ doc }) => (doc?.adjectives().out('array').length ?? 0) > 0,
+  adverbs: ({ doc }) => (doc?.adverbs().out('array').length ?? 0) > 0,
+  verbs: ({ doc }) => (doc?.verbs().out('array').length ?? 0) > 0,
+  progressiveVerbs: ({ text }) => /\b(?:is|are|was|were)\s+\w+ing\b/i.test(text),
+  pronouns: ({ text }) =>
+    new RegExp(`\\b(${pronouns.map(escapeRegex).join('|')})\\b`, 'i').test(text),
+  determiners: ({ text }) =>
+    new RegExp(`\\b(${determiners.map(escapeRegex).join('|')})\\b`, 'i').test(text),
+  prepositions: ({ text }) =>
+    new RegExp(`\\b(${prepositions.map(escapeRegex).join('|')})\\b`, 'i').test(text),
+  commasInLists: ({ text }) => /\w+,\s+\w+,\s+(?:and|or)\s+\w+/i.test(text),
+  apostrophes: ({ text }) => /['’]/.test(text)
+};
+
+export const analyseTextAgainstGrammar = (text) => {
+  const trimmed = text.trim();
+  const sentences = trimmed ? sentenceSplitter(trimmed) : [];
+  const doc = trimmed ? nlp(trimmed) : null;
+  const context = { text: trimmed, sentences, doc };
+
+  return grammarObjectives.map((objective) => ({
+    ...objective,
+    met: detectors[objective.id]?.(context) ?? false
+  }));
+};
+
+export const summariseGrammarNeeds = (analysis) =>
+  analysis.filter((item) => !item.met).map((item) => ({
+    id: item.id,
+    label: item.label,
+    tip: item.tip,
+    stage: item.stage,
+    examples: item.examples
+  }));


### PR DESCRIPTION
## Summary
- scale up the document toolbar, canvas, and scaffold styling to make the interface easier to read and tap
- analyse prose against the UK grammar appendix to drive smarter predictive chips and provide a GrammarCoach panel with curriculum-aligned prompts
- add a SpellCheckPanel using a UK nspell dictionary plus a SpeechControls panel for configurable text-to-speech playback

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea727e1a48322b9e4b26e2a1f47f7