### PR TITLE
Redesign writing workspace layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,14 +1,14 @@
 :root {
-  color: #202124;
+  color: #1e293b;
   font-family: 'Inter', 'Roboto', sans-serif;
-  background-color: #f1f3f4;
+  background-color: #eef2ff;
   font-size: clamp(18px, 1vw + 17px, 22px);
   line-height: 1.7;
 }
 
 body {
   margin: 0;
-  background-color: #f1f3f4;
+  background-color: #eef2ff;
   font-size: 1.05rem;
 }
 
@@ -30,93 +30,177 @@ body {
 
 .app-shell {
   min-height: 100vh;
+}
+
+.writing-hub {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.95), rgba(226, 232, 240, 0.85)),
+    linear-gradient(180deg, #eef2ff 0%, #e0e7ff 100%);
+  padding: clamp(1.5rem, 4vw, 3rem);
   display: flex;
   flex-direction: column;
-  background-color: #f1f3f4;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
-.app-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2.75rem;
-  background: #f8f9fa;
-  border-bottom: 1px solid #dadce0;
-  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.1);
-  position: sticky;
-  top: 0;
-  z-index: 20;
+.workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 22%) minmax(0, 1fr) minmax(300px, 24%);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: start;
 }
 
-.app-toolbar__left {
+.workspace-panel {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.panel-block {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 22px;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(14px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.panel-block__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  color: #1d4ed8;
+}
+
+.panel-block__header h2,
+.panel-block__header h3 {
+  margin: 0;
+}
+
+.panel-block__header p {
+  margin: 0.4rem 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.panel-block--word-bank {
   gap: 1.25rem;
 }
 
+.panel-block--coach {
+  background: rgba(30, 64, 175, 0.08);
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  color: #1d4ed8;
+}
+
+.panel-block--coach h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.panel-block--coach p {
+  margin: 0;
+  font-weight: 600;
+}
+
+.panel-block--coach ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #0f172a;
+  font-size: 0.95rem;
+}
+
+.workspace-center {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.workspace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  background: rgba(255, 255, 255, 0.96);
+  padding: clamp(1rem, 3vw, 1.5rem) clamp(1.2rem, 4vw, 2.5rem);
+  border-radius: 26px;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  backdrop-filter: blur(16px);
+}
+
+.workspace-header__identity {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+}
+
+.workspace-header__controls {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.9rem, 2vw, 1.5rem);
+}
+
 .app-logo {
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
-  background: linear-gradient(135deg, #1a73e8, #4285f4);
-  box-shadow: 0 4px 12px rgba(26, 115, 232, 0.25);
+  background: linear-gradient(135deg, #3730a3, #6366f1);
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.4);
 }
 
 .doc-meta {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 
 .doc-title-input {
   border: none;
   background: transparent;
-  font-size: 1.4rem;
+  font-size: clamp(1.35rem, 0.5vw + 1.2rem, 1.7rem);
   font-weight: 700;
-  color: #202124;
+  color: #0f172a;
   padding: 0.15rem 0;
 }
 
 .doc-title-input:focus {
   outline: none;
-  border-bottom: 1px solid #1a73e8;
+  box-shadow: inset 0 -2px 0 0 #6366f1;
 }
 
 .doc-menu {
   display: flex;
-  gap: 1.5rem;
-  color: #5f6368;
-  font-size: 1rem;
+  gap: 1.35rem;
+  color: #475569;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
 }
 
 .doc-menu span {
   cursor: pointer;
+  transition: color 0.2s ease;
 }
 
 .doc-menu span:hover {
-  color: #1a73e8;
-}
-
-.app-toolbar__right {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
+  color: #1d4ed8;
 }
 
 .support-selector {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  background: #fff;
-  border: 1px solid #dadce0;
+  gap: 0.7rem;
+  background: rgba(99, 102, 241, 0.12);
   border-radius: 999px;
-  padding: 0.65rem 1.4rem;
-  color: #3c4043;
-  font-size: 1rem;
+  padding: 0.6rem 1.4rem;
+  color: #312e81;
+  font-size: 0.95rem;
+  border: 1px solid rgba(99, 102, 241, 0.18);
 }
 
 .support-selector label {
@@ -128,14 +212,14 @@ body {
   background: transparent;
   font-size: 1rem;
   color: inherit;
-  padding-right: 1.75rem;
+  padding-right: 1.4rem;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23525691' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
   background-repeat: no-repeat;
-  background-position: right 0.15rem center;
-  background-size: 1rem;
+  background-position: right 0.1rem center;
+  background-size: 0.85rem;
 }
 
 .support-selector select:focus {
@@ -145,236 +229,391 @@ body {
 .share-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   border: none;
-  background: #1a73e8;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
   color: #fff;
   border-radius: 999px;
-  padding: 0.75rem 1.6rem;
+  padding: 0.7rem 1.6rem;
   font-weight: 600;
   font-size: 1rem;
   cursor: pointer;
-  box-shadow: 0 1px 2px rgba(26, 115, 232, 0.35);
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
 }
 
 .share-button:hover {
-  background: #1765cc;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 34px rgba(99, 102, 241, 0.5);
+}
+
+.share-button--halo {
+  position: relative;
+}
+
+.share-button--halo::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  opacity: 0.7;
+}
+
+.workspace-orbit {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.4rem, 3vw, 2rem);
 }
 
 .format-toolbar {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: clamp(0.9rem, 2vw, 1.35rem) clamp(1.1rem, 3vw, 2rem);
+  box-shadow: 0 24px 44px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(18px);
+}
+
+.format-toolbar__cluster {
+  display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 2.75rem;
-  background: #fff;
-  border-bottom: 1px solid #dadce0;
-  position: sticky;
-  top: 96px;
-  z-index: 15;
+  gap: 0.55rem;
 }
 
-.format-toolbar__divider {
-  width: 1px;
-  height: 32px;
-  background: #dadce0;
-  margin: 0 0.5rem;
-}
-
-.format-toolbar__spacer {
-  flex: 1;
+.format-toolbar__cluster--actions {
+  margin-left: auto;
 }
 
 .format-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
   border: 1px solid transparent;
-  background: transparent;
-  padding: 0.6rem 0.85rem;
-  border-radius: 8px;
-  color: #3c4043;
-  font-size: 1rem;
+  background: rgba(99, 102, 241, 0.08);
+  padding: 0.6rem 0.95rem;
+  border-radius: 12px;
+  color: #312e81;
+  font-size: 0.95rem;
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border 0.2s ease;
 }
 
 .format-button:hover {
-  background: rgba(26, 115, 232, 0.08);
-  border-color: rgba(26, 115, 232, 0.12);
+  transform: translateY(-1px);
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 8px 18px rgba(99, 102, 241, 0.25);
 }
 
-.doc-layout {
-  display: flex;
-  flex: 1;
-  align-items: flex-start;
-  gap: 2.5rem;
-  padding: 2.5rem 2.75rem 3rem;
-}
-
-.doc-wrapper {
-  flex: 1;
+.editor-stack {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  max-width: 1100px;
-  margin: 0 auto;
+  gap: clamp(1rem, 2.5vw, 1.6rem);
 }
 
-.suggestion-bar {
-  background: #fff;
-  border-radius: 12px;
-  border: 1px solid #e8eaed;
-  box-shadow: 0 4px 12px rgba(60, 64, 67, 0.1);
-  padding: 1.2rem 1.4rem;
+.ghost-suggestions {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
+  align-items: stretch;
+  color: #475569;
 }
 
-.suggestion-bar__header {
+.ghost-suggestions__header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  color: #1a73e8;
-  font-weight: 700;
-  font-size: 1.1rem;
+  gap: 0.65rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #334155;
 }
 
-.suggestion-bar__chips {
+.ghost-suggestions__list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.5rem;
 }
 
 .suggestion-chip {
-  padding: 0.65rem 1.1rem;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid #c6dafc;
-  background: #e8f0fe;
-  color: #1a73e8;
-  font-size: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: rgba(226, 232, 240, 0.55);
+  color: #64748b;
+  font-size: 0.95rem;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  transition: transform 0.15s ease, border 0.2s ease, background 0.2s ease;
 }
 
 .suggestion-chip:hover {
   transform: translateY(-1px);
-  box-shadow: 0 3px 8px rgba(26, 115, 232, 0.25);
+  border-color: rgba(99, 102, 241, 0.35);
+  background: rgba(226, 232, 240, 0.85);
 }
 
 .suggestion-empty {
-  color: #5f6368;
-  font-size: 1rem;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  font-style: italic;
 }
 
 .support-badge {
-  padding: 0.25rem 0.75rem;
+  padding: 0.2rem 0.75rem;
   border-radius: 999px;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.18);
+  color: #1f2937;
 }
 
 .support-badge--beginner {
-  background: #e8f5e9;
-  color: #1b5e20;
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
 }
 
 .support-badge--intermediate {
-  background: #fff3e0;
-  color: #e65100;
+  background: rgba(251, 146, 60, 0.2);
+  color: #c2410c;
 }
 
 .support-badge--advanced {
-  background: #fce4ec;
-  color: #ad1457;
+  background: rgba(244, 114, 182, 0.22);
+  color: #be185d;
 }
 
-.doc-page-wrapper {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.95));
-  border-radius: 16px;
-  padding: 2rem;
-  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.15);
-  border: 1px solid #e8eaed;
-}
-
-.doc-page {
-  min-height: 1040px;
-  background: #fff;
-  border-radius: 8px;
-  padding: 2rem;
-  font-size: 1.15rem;
-  line-height: 1.8;
-  color: #202124;
-  outline: none;
+.editor-shell {
   position: relative;
-  box-shadow: inset 0 0 0 1px rgba(218, 220, 224, 0.7);
-  white-space: pre-wrap;
-  word-break: break-word;
+  padding: clamp(1.2rem, 3vw, 2rem);
+  border-radius: 32px;
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.12), transparent 65%),
+    rgba(255, 255, 255, 0.92);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(18px);
 }
 
-.doc-page:focus {
-  box-shadow: inset 0 0 0 2px #1a73e8;
-}
-
-.doc-page[data-placeholder][data-has-content='false']::before {
-  content: attr(data-placeholder);
-  color: #9aa0a6;
+.editor-shell__glow {
   position: absolute;
-  top: 2rem;
-  left: 2rem;
+  inset: 10% 12%;
+  border-radius: 32px;
+  background: radial-gradient(circle, rgba(129, 140, 248, 0.22), transparent 70%);
+  filter: blur(36px);
   pointer-events: none;
 }
 
-.doc-status-bar {
+.writing-editor-wrapper {
+  position: relative;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 1rem;
-  color: #5f6368;
-  padding: 0.85rem 1.1rem;
-  border-radius: 14px;
+  justify-content: center;
+}
+
+.writing-editor {
+  width: min(760px, 100%);
+  min-height: 720px;
   background: #fff;
-  border: 1px solid #e8eaed;
+  border-radius: 28px;
+  padding: clamp(2.5rem, 4vw, 3.5rem);
+  font-size: 1.18rem;
+  line-height: 1.85;
+  color: #0f172a;
+  outline: none;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  white-space: pre-wrap;
+  word-break: break-word;
+  position: relative;
 }
 
-.doc-status-bar__tip {
-  color: #1a73e8;
+.writing-editor:focus {
+  border-color: #6366f1;
+  box-shadow: 0 28px 56px rgba(99, 102, 241, 0.22);
 }
 
-.scaffold-panel {
-  width: 380px;
-  flex-shrink: 0;
+.writing-editor[data-placeholder][data-has-content='false']::before {
+  content: attr(data-placeholder);
+  position: absolute;
+  top: clamp(2.5rem, 4vw, 3.5rem);
+  left: clamp(2.5rem, 4vw, 3.5rem);
+  color: #cbd5f5;
+  pointer-events: none;
+  font-style: italic;
+}
+
+.word-token {
+  position: relative;
+  padding: 0 0.05em;
+  border-radius: 0.45em;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.word-token--noun {
+  color: #1d4ed8;
+}
+
+.word-token--verb {
+  color: #db2777;
+}
+
+.word-token--adjective {
+  color: #c2410c;
+}
+
+.word-token--adverb {
+  color: #6d28d9;
+}
+
+.word-token--determiner {
+  color: #0f766e;
+}
+
+.word-token--conjunction {
+  color: #f97316;
+}
+
+.word-token--preposition {
+  color: #8b5cf6;
+}
+
+.word-token--pronoun {
+  color: #ef4444;
+}
+
+.word-token--unknown {
+  color: #334155;
+}
+
+.word-token--spell-issue {
+  text-decoration: underline wavy #dc2626 2px;
+  text-decoration-skip-ink: none;
+}
+
+.orbit-footer {
+  display: flex;
+  gap: clamp(1.2rem, 3vw, 1.8rem);
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.tts-controls {
+  flex: 1 1 320px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 24px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  background: #fff;
-  border-radius: 16px;
-  padding: 1.75rem;
-  border: 1px solid #e8eaed;
-  box-shadow: 0 10px 24px rgba(60, 64, 67, 0.12);
+  gap: 1rem;
 }
 
-.scaffold-panel__header {
+.tts-controls__summary {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  gap: 0.85rem;
+  color: #1d4ed8;
+}
+
+.tts-controls__summary h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.tts-controls__summary p {
+  margin: 0.2rem 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.tts-controls__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.75rem;
 }
 
-.scaffold-panel__header h2 {
-  margin: 0;
-  font-size: 1.35rem;
+.tts-select {
+  min-width: 180px;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(237, 233, 254, 0.6);
+  color: #312e81;
+  font-size: 0.95rem;
 }
 
-.scaffold-panel__header p {
-  margin: 0.35rem 0 0;
-  font-size: 1rem;
-  color: #5f6368;
+.tts-select:focus {
+  outline: 2px solid rgba(99, 102, 241, 0.4);
+}
+
+.tts-controls__buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tts-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: #fff;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.tts-button:disabled {
+  background: rgba(148, 163, 184, 0.5);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.tts-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 26px rgba(79, 70, 229, 0.4);
+}
+
+.tts-voice-loading,
+.tts-controls__unsupported {
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.status-band {
+  flex: 1 1 220px;
+  background: rgba(30, 64, 175, 0.08);
+  border-radius: 24px;
+  padding: 1.1rem 1.4rem;
+  border: 1px dashed rgba(30, 64, 175, 0.35);
+  color: #1e3a8a;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.status-band__count {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.status-band__tip {
+  font-size: 0.95rem;
 }
 
 .word-bank-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .word-bank-tab {
@@ -383,11 +622,17 @@ body {
   gap: 0.55rem;
   padding: 0.55rem 1rem;
   border-radius: 999px;
-  border: 1px solid #dadce0;
-  background: #f8f9fa;
-  color: #3c4043;
-  font-size: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.8);
+  color: #1f2937;
+  font-size: 0.95rem;
   cursor: pointer;
+  transition: border 0.2s ease, transform 0.15s ease;
+}
+
+.word-bank-tab:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 102, 241, 0.35);
 }
 
 .word-bank-tab__dot {
@@ -397,214 +642,52 @@ body {
 }
 
 .word-bank-tab--active {
-  border-color: #1a73e8;
-  background: #e8f0fe;
-  color: #1a73e8;
+  border-color: #4f46e5;
+  background: rgba(129, 140, 248, 0.18);
+  color: #1e40af;
 }
 
 .word-bank-items {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  display: grid;
+  gap: 0.7rem;
   max-height: 420px;
-  overflow: auto;
-  padding-right: 0.35rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .word-bank-item {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  border: 1px solid #e8eaed;
-  border-radius: 12px;
-  padding: 0.8rem 1.1rem;
-  background: #fff;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.85);
   cursor: pointer;
-  text-align: left;
-  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border 0.2s ease;
 }
 
 .word-bank-item:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(26, 115, 232, 0.18);
-  border-color: #c6dafc;
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
 }
 
 .word-bank-item__text {
-  font-size: 1.1rem;
   font-weight: 600;
-  color: #1a73e8;
+  color: #0f172a;
 }
 
 .word-bank-item__hint {
-  font-size: 0.9rem;
-  color: #5f6368;
-  margin-top: 0.2rem;
+  color: #64748b;
+  font-size: 0.85rem;
 }
 
 .word-bank-empty {
-  color: #5f6368;
-  font-size: 1rem;
-  margin: 0;
-}
-
-.support-card {
-  border-radius: 14px;
-  background: linear-gradient(135deg, rgba(26, 115, 232, 0.08), rgba(26, 115, 232, 0.15));
-  padding: 1.4rem;
-  color: #174ea6;
-  border: 1px solid rgba(26, 115, 232, 0.15);
-}
-
-.support-card h3 {
-  margin: 0 0 0.6rem;
-  font-size: 1.2rem;
-}
-
-.support-card p {
-  margin: 0 0 1rem;
-  font-size: 1rem;
-}
-
-.support-card ul {
-  padding-left: 1.1rem;
   margin: 0;
   font-size: 0.95rem;
-}
-
-.support-card li {
-  margin-bottom: 0.3rem;
-}
-
-.tts-controls {
-  background: #fff;
-  border: 1px solid #e8eaed;
-  border-radius: 16px;
-  padding: 1.4rem 1.6rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  box-shadow: 0 6px 16px rgba(60, 64, 67, 0.12);
-}
-
-.tts-controls__summary {
-  display: flex;
-  gap: 1rem;
-  align-items: flex-start;
-  color: #174ea6;
-}
-
-.tts-controls__summary h3 {
-  margin: 0;
-  font-size: 1.25rem;
-}
-
-.tts-controls__summary p {
-  margin: 0.35rem 0 0;
-  color: #5f6368;
-  font-size: 1rem;
-}
-
-.tts-controls__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.tts-select {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  border: 1px solid #d2d5d9;
-  font-size: 1rem;
-  color: #3c4043;
-}
-
-.tts-voice-loading {
-  color: #5f6368;
-  font-style: italic;
-}
-
-.tts-controls__buttons {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.tts-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid #d2d5d9;
-  background: #f1f3f4;
-  color: #202124;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.tts-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.tts-button:hover:not(:disabled) {
-  background: #e8f0fe;
-  transform: translateY(-1px);
-}
-
-.tts-controls__unsupported {
-  margin: 0;
-  color: #5f6368;
-  font-size: 1rem;
-}
-
-.insight-card {
-  border-radius: 16px;
-  border: 1px solid #e8eaed;
-  background: #fff;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  box-shadow: 0 6px 16px rgba(60, 64, 67, 0.1);
-}
-
-.insight-card__header {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  color: #1a73e8;
-}
-
-.insight-card__header h3 {
-  margin: 0;
-  font-size: 1.25rem;
-}
-
-.insight-card__header p {
-  margin: 0.25rem 0 0;
-  color: #5f6368;
-}
-
-.insight-card__section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.insight-card__section h4 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: #202124;
-}
-
-.insight-card__loading,
-.insight-card__success {
-  margin: 0;
-  color: #5f6368;
+  color: #94a3b8;
 }
 
 .insight-list {
@@ -613,183 +696,215 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
 }
 
 .insight-list--compact {
-  gap: 0.4rem;
+  gap: 0.55rem;
+}
+
+.insight-card__loading {
+  color: #64748b;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.insight-card__success {
+  color: #0f766e;
+  font-weight: 600;
+  margin: 0;
+}
+
+.insight-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.insight-card__section--success {
+  background: rgba(16, 185, 129, 0.12);
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(16, 185, 129, 0.35);
 }
 
 .spell-issue {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem 0.9rem;
-  border-radius: 12px;
-  border: 1px solid #f0c7c7;
-  background: #fff7f7;
+  gap: 0.7rem;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: rgba(254, 226, 226, 0.4);
 }
 
 .spell-issue__meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.5rem;
+  color: #b91c1c;
+  font-weight: 600;
 }
 
 .spell-issue__word {
-  font-weight: 700;
   font-size: 1.05rem;
-  color: #c5221f;
 }
 
 .spell-issue__count {
-  color: #5f6368;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .spell-issue__actions {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .spell-issue__suggestion {
   border: none;
   border-radius: 999px;
-  background: #e8f0fe;
-  color: #1a73e8;
-  padding: 0.4rem 0.9rem;
+  padding: 0.45rem 0.9rem;
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 0.95rem;
 }
 
 .spell-issue__suggestion:hover {
-  background: #d2e3fc;
+  background: rgba(248, 113, 113, 0.3);
 }
 
 .spell-issue__no-suggestion {
-  color: #5f6368;
-  font-style: italic;
+  color: #9f1239;
+  font-size: 0.9rem;
 }
 
 .grammar-target {
+  border-radius: 14px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(239, 246, 255, 0.6);
+  padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 12px;
-  border: 1px solid #e8eaed;
+  gap: 0.65rem;
 }
 
 .grammar-target__summary {
   display: flex;
-  gap: 0.6rem;
-  align-items: flex-start;
+  align-items: center;
+  gap: 0.65rem;
+  color: #1d4ed8;
 }
 
 .grammar-target__label {
   display: block;
-  font-weight: 700;
-  color: #202124;
+  font-weight: 600;
 }
 
 .grammar-target__stage {
   display: block;
   font-size: 0.85rem;
-  color: #5f6368;
+  color: #334155;
 }
 
 .grammar-target__description {
   margin: 0;
-  color: #3c4043;
+  color: #334155;
   font-size: 0.95rem;
 }
 
 .grammar-target__tip {
   margin: 0;
-  color: #1a73e8;
-  font-style: italic;
+  color: #1e3a8a;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
 .grammar-target__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .grammar-target__chip {
   border: none;
   border-radius: 999px;
-  padding: 0.45rem 0.85rem;
-  background: #e8f5e9;
-  color: #0b8043;
+  padding: 0.45rem 0.9rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: #3730a3;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 0.95rem;
 }
 
 .grammar-target__chip:hover {
-  background: #c8e6c9;
+  background: rgba(99, 102, 241, 0.3);
 }
 
 .grammar-target--achieved {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  color: #0b8043;
+  gap: 0.45rem;
+  color: #0f766e;
 }
 
-.insight-card__section--success {
-  border-top: 1px solid #e8eaed;
-  padding-top: 0.75rem;
+@media (max-width: 1300px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .workspace-panel--right {
+    order: 3;
+  }
+
+  .workspace-panel--left {
+    order: 1;
+  }
+
+  .workspace-center {
+    order: 2;
+  }
 }
 
-@media (max-width: 1200px) {
-  .doc-layout {
+@media (max-width: 960px) {
+  .writing-hub {
+    padding: clamp(1rem, 4vw, 1.5rem);
+  }
+
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-header {
     flex-direction: column;
+    align-items: stretch;
   }
 
-  .scaffold-panel {
-    width: 100%;
-  }
-}
-
-@media (max-width: 768px) {
-  .app-toolbar,
-  .format-toolbar {
-    position: static;
-  }
-
-  .doc-layout {
-    padding: 1rem;
-  }
-
-  .doc-wrapper {
-    width: 100%;
-  }
-
-  .app-toolbar__right {
-    flex-direction: column;
-    align-items: flex-end;
-  }
-
-  .support-selector {
-    width: 100%;
+  .workspace-header__controls {
     justify-content: space-between;
   }
+
+  .format-toolbar__cluster--actions {
+    margin-left: 0;
+  }
+
+  .orbit-footer {
+    flex-direction: column;
+  }
+
+  .status-band {
+    width: 100%;
+  }
 }
 
-@media (max-width: 600px) {
-  .doc-menu {
-    display: none;
-  }
-
-  .format-toolbar {
-    flex-wrap: wrap;
-    gap: 0.25rem;
-  }
-
-  .format-toolbar__spacer {
-    display: none;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the writing workspace so the editor sits at the centre with toolbar, suggestions, TTS controls, word bank and insight cards orbiting it
- detect word classes to colour-code tokens while underlining spelling issues with a red squiggle and present predictive suggestions as soft grey chips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceade2eec08322b219bd7aeafa1cdc