### PR TITLE
Create animated word garden interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "autoprefixer": "^10.4.20",
         "compromise": "^14.14.4",
         "dictionary-en": "^4.0.0",
+        "framer-motion": "^12.23.16",
         "lucide-react": "^0.469.0",
         "nspell": "^2.1.5",
         "papaparse": "^5.4.1",
@@ -2849,6 +2850,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
+      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3906,6 +3934,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "autoprefixer": "^10.4.20",
     "compromise": "^14.14.4",
     "dictionary-en": "^4.0.0",
+    "framer-motion": "^12.23.16",
     "lucide-react": "^0.469.0",
     "nspell": "^2.1.5",
     "papaparse": "^5.4.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,7 @@
-import './App.css';
-import EALDocs from './components/EALDocs';
+import WordGarden from './components/WordGarden';
 
 function App() {
-  return <EALDocs />;
+  return <WordGarden />;
 }
 
 export default App;

--- a/src/components/WordGarden.jsx
+++ b/src/components/WordGarden.jsx
@@ -1,0 +1,469 @@
+import PropTypes from 'prop-types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertTriangle, Dot, Save, Volume2 } from 'lucide-react';
+
+const DICTIONARY = [
+  'cat',
+  'catch',
+  'caterpillar',
+  'castle',
+  'car',
+  'card',
+  'care',
+  'careful',
+  'dog',
+  'door',
+  'down',
+  'draw',
+  'dream',
+  'drift',
+  'dragon',
+  'drop',
+  'apple',
+  'apricot',
+  'astronaut',
+  'ask',
+  'asleep',
+  'after',
+  'again',
+  'quick',
+  'quiet',
+  'quiver',
+  'queen',
+  'question',
+  'quack',
+  'happy',
+  'happen',
+  'harbor',
+  'harmony',
+  'harvest',
+  'hat',
+  'play',
+  'plane',
+  'planet',
+  'please',
+  'place',
+  'story',
+  'stork',
+  'storm',
+  'store',
+  'stone',
+  'strong',
+  'bright',
+  'bring',
+  'breeze',
+  'bread',
+  'break',
+  'blue',
+  'black',
+  'brown',
+  'brave',
+  'broom',
+  'green',
+  'gold',
+  'glow',
+  'glide',
+  'glitter',
+  'sun',
+  'sand',
+  'song',
+  'sound',
+  'soft',
+  'some',
+  'time',
+  'tiny',
+  'tiger',
+  'tired',
+  'tickle',
+  'magic',
+  'make',
+  'made',
+  'many',
+  'march',
+  'marble'
+];
+
+const PUNCT = ['.', ',', '!', '?', '…', ';', ':'];
+
+const GRADIENTS = [
+  'linear-gradient(135deg, rgba(255,0,132,1) 0%, rgba(255,140,0,1) 50%, rgba(255,237,0,1) 100%)',
+  'linear-gradient(135deg, rgba(0,167,255,1) 0%, rgba(0,242,195,1) 50%, rgba(255,0,224,1) 100%)',
+  'linear-gradient(135deg, rgba(98,0,234,1) 0%, rgba(236,64,122,1) 50%, rgba(253,216,53,1) 100%)',
+  'linear-gradient(135deg, rgba(0,200,83,1) 0%, rgba(0,176,255,1) 50%, rgba(156,39,176,1) 100%)',
+  'linear-gradient(135deg, rgba(13,71,161,1) 0%, rgba(3,155,229,1) 50%, rgba(0,230,118,1) 100%)'
+];
+
+const PLACEHOLDER_ROOT = 'Start your story';
+
+function pickRandom(arr, n) {
+  const pool = [...arr];
+  const result = [];
+  while (result.length < n && pool.length) {
+    const index = Math.floor(Math.random() * pool.length);
+    result.push(pool.splice(index, 1)[0]);
+  }
+  return result;
+}
+
+function sizeForRank(rank) {
+  if (rank === 0) return 'text-6xl md:text-7xl';
+  if (rank === 1) return 'text-5xl md:text-6xl';
+  return 'text-4xl md:text-5xl';
+}
+
+async function predictNext(context, currentWord) {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+
+  const prefix = currentWord.toLowerCase();
+  let candidates = DICTIONARY.filter((word) => word.startsWith(prefix));
+
+  if (prefix.length === 0) {
+    const tokens = context
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    const last = tokens.at(-1) ?? '';
+    candidates = last
+      ? DICTIONARY.filter((word) => word.startsWith(last[0]))
+      : pickRandom(DICTIONARY, 10);
+  }
+
+  const pool = candidates.length ? candidates : pickRandom(DICTIONARY, 10);
+  return { words: pool.slice(0, 3), punctuation: PUNCT };
+}
+
+function randomGradientStep() {
+  return 1 + Math.floor(Math.random() * (GRADIENTS.length - 1));
+}
+
+export default function WordGarden() {
+  const [sentence, setSentence] = useState('');
+  const [current, setCurrent] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [punctuation, setPunctuation] = useState(PUNCT);
+  const [bgIndex, setBgIndex] = useState(0);
+  const [errorFlag, setErrorFlag] = useState(false);
+  const inputRef = useRef(null);
+
+  const focusNode = useMemo(() => {
+    const trimmedCurrent = current.trim();
+    if (trimmedCurrent) {
+      return trimmedCurrent;
+    }
+    const trimmedSentence = sentence.trim();
+    return trimmedSentence || PLACEHOLDER_ROOT;
+  }, [current, sentence]);
+
+  useEffect(() => {
+    const prefix = current.trim().toLowerCase();
+    if (prefix.length >= 3) {
+      const exists = DICTIONARY.some((word) => word.startsWith(prefix));
+      setErrorFlag(!exists);
+    } else {
+      setErrorFlag(false);
+    }
+  }, [current]);
+
+  useEffect(() => {
+    let alive = true;
+    predictNext(sentence, current).then((result) => {
+      if (!alive) return;
+      setSuggestions(result.words);
+      setPunctuation(result.punctuation);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [sentence, current]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const backgroundStyle = useMemo(
+    () => ({
+      backgroundImage: GRADIENTS[bgIndex % GRADIENTS.length]
+    }),
+    [bgIndex]
+  );
+
+  const ranked = suggestions.slice(0, 3);
+
+  function resetInput() {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+    setCurrent('');
+  }
+
+  function commitWord(word) {
+    const safeWord = word.trim();
+    if (!safeWord) {
+      resetInput();
+      return;
+    }
+
+    setSentence((prev) => {
+      const trimmed = prev.trim();
+      const nextSentence = trimmed ? `${trimmed} ${safeWord}` : safeWord;
+      return `${nextSentence} `;
+    });
+
+    resetInput();
+    setBgIndex((index) => (index + randomGradientStep()) % GRADIENTS.length);
+  }
+
+  function commitPunctuation(mark) {
+    setSentence((prev) => {
+      const typed = current.trim();
+      const trimmedPrev = prev.trim();
+      const base = typed ? (trimmedPrev ? `${trimmedPrev} ${typed}` : typed) : trimmedPrev;
+      const needsSpace = [',', ';', ':'].includes(mark);
+      const post = needsSpace ? ' ' : ' ';
+      if (!base) {
+        return `${mark}${post}`;
+      }
+      return `${base}${mark}${post}`;
+    });
+
+    resetInput();
+    setBgIndex((index) => (index + randomGradientStep()) % GRADIENTS.length);
+  }
+
+  function speak(text) {
+    if (typeof window === 'undefined' || !text) {
+      return;
+    }
+    try {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'en-GB';
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    } catch (error) {
+      console.warn('Speech synthesis failed', error);
+    }
+  }
+
+  function handleChange(event) {
+    const { value } = event.target;
+    if (/\s/.test(value)) {
+      const safe = current.trim();
+      if (safe) {
+        commitWord(safe);
+      }
+      resetInput();
+      return;
+    }
+    setCurrent(value);
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const safe = current.trim();
+      if (safe) {
+        commitWord(safe);
+      }
+      return;
+    }
+
+    if (event.key === 'Backspace' && current.length === 0) {
+      event.preventDefault();
+      setSentence((prev) => {
+        const trimmed = prev.trim();
+        if (!trimmed) {
+          return '';
+        }
+        const parts = trimmed.split(/\s+/);
+        parts.pop();
+        return parts.length ? `${parts.join(' ')} ` : '';
+      });
+    }
+  }
+
+  function handleSave() {
+    try {
+      const payload = { sentence: sentence.trim(), ts: Date.now() };
+      const existing = JSON.parse(localStorage.getItem('wordgarden:saves') ?? '[]');
+      const updated = [payload, ...existing].slice(0, 50);
+      localStorage.setItem('wordgarden:saves', JSON.stringify(updated));
+    } catch (error) {
+      console.warn('Unable to save story', error);
+    }
+  }
+
+  return (
+    <div
+      className="relative flex h-screen w-screen select-none items-center justify-center overflow-hidden"
+      onMouseDown={() => inputRef.current?.focus()}
+    >
+      <motion.div
+        key={bgIndex}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.8 }}
+        className="absolute inset-0"
+        style={{
+          ...backgroundStyle,
+          backgroundSize: '200% 200%',
+          filter: 'saturate(1.1)'
+        }}
+      />
+
+      <div className="absolute inset-0 bg-gradient-to-br from-black/20 via-black/15 to-black/30" />
+
+      <div className="absolute right-4 top-4 z-30">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="flex items-center gap-2 rounded-2xl bg-white/85 px-4 py-2 text-sm font-semibold text-slate-900 shadow-lg backdrop-blur hover:bg-white"
+        >
+          <Save className="h-5 w-5" />
+          Save
+        </button>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="text"
+        autoFocus
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className="absolute h-0 w-0 opacity-0"
+        aria-hidden
+      />
+
+      <div className="relative z-20 flex h-full w-full flex-col items-center justify-center px-6">
+        <div className="max-w-5xl text-center text-white/95 drop-shadow-[0_2px_4px_rgba(0,0,0,0.5)]">
+          <p className="text-2xl md:text-3xl leading-relaxed">
+            {sentence}
+            <span
+              className={`inline-block min-w-[1ch] border-b-2 ${
+                errorFlag ? 'border-red-400' : 'border-white/80'
+              }`}
+            >
+              {current}
+            </span>
+            <span className="ml-0.5 animate-pulse">|</span>
+          </p>
+          <AnimatePresence>
+            {errorFlag ? (
+              <motion.div
+                key="error"
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                className="mt-3 inline-flex items-center gap-2 rounded-full bg-red-500/20 px-4 py-2 text-sm text-red-100 backdrop-blur"
+              >
+                <AlertTriangle className="h-4 w-4" />
+                Keep an eye on that spelling – it looks unusual!
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+
+        <div className="mt-16 w-full max-w-6xl px-4">
+          <div className="flex flex-col items-center gap-16">
+            <motion.div
+              key={focusNode}
+              layout
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: -10 }}
+              transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+              className="relative"
+            >
+              <div className="rounded-3xl bg-white/20 px-6 py-3 text-xl font-semibold text-white/90 shadow-xl backdrop-blur">
+                {focusNode}
+              </div>
+              <div className="absolute -bottom-14 left-1/2 h-14 w-px -translate-x-1/2 bg-white/40" aria-hidden />
+            </motion.div>
+
+            <div className="relative flex w-full max-w-4xl items-start justify-center gap-10">
+              <div className="absolute -top-8 left-[10%] right-[10%] h-px bg-white/35" aria-hidden />
+              <AnimatePresence>
+                {ranked.map((word, index) => (
+                  <motion.div
+                    key={word}
+                    layout
+                    initial={{ opacity: 0, y: 30, scale: 0.9 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: -30, scale: 0.9 }}
+                    transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+                    className="relative flex flex-col items-center"
+                  >
+                    <div className="absolute -top-8 h-8 w-px bg-white/35" aria-hidden />
+                    <SuggestionNode
+                      word={word}
+                      rank={index}
+                      onPick={() => commitWord(word)}
+                      onSpeak={() => speak(word)}
+                    />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-wrap items-center justify-center gap-3 text-white/90">
+          {punctuation.map((mark) => (
+            <button
+              key={mark}
+              type="button"
+              onClick={() => commitPunctuation(mark)}
+              className="rounded-xl bg-white/80 px-4 py-2 text-lg font-semibold text-slate-800 shadow hover:bg-white"
+              aria-label={`Insert ${mark}`}
+            >
+              {mark}
+            </button>
+          ))}
+          <span className="mx-2 text-white/60">|</span>
+          <span className="inline-flex items-center gap-1 text-white/90">
+            <AlertTriangle className="h-4 w-4" />
+            error
+          </span>
+          <span className="inline-flex items-center gap-1 text-white/90">
+            <Dot className="h-5 w-5" />
+            pause
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SuggestionNode({ word, rank, onPick, onSpeak }) {
+  return (
+    <div className="group flex flex-col items-center">
+      <motion.button
+        type="button"
+        layout
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.98 }}
+        onClick={onPick}
+        className={`font-bold text-white ${sizeForRank(rank)} tracking-wide drop-shadow-[0_4px_6px_rgba(0,0,0,0.45)]`}
+      >
+        {word}
+      </motion.button>
+      <button
+        type="button"
+        onClick={onSpeak}
+        className="mt-3 rounded-full bg-white/90 p-2 text-slate-900 opacity-0 shadow transition-opacity group-hover:opacity-100"
+        aria-label={`Speak ${word}`}
+      >
+        <Volume2 className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+SuggestionNode.propTypes = {
+  word: PropTypes.string.isRequired,
+  rank: PropTypes.number.isRequired,
+  onPick: PropTypes.func.isRequired,
+  onSpeak: PropTypes.func.isRequired
+};
+


### PR DESCRIPTION
## Summary
- replace the previous document builder with the full-screen WordGarden experience that surfaces three adaptive suggestions in a horizontal "family tree" layout, plus punctuation, save, and error cues
- implement a placeholder prediction machine that reacts to the live sentence/word being typed and animates the background gradients on each commit
- install framer-motion to power smooth transitions and scaling effects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee7ff7ea08322854912572f6fb74a