### PR TITLE
Fix inline suggestions and word mat insertion

### DIFF
--- a/src/components/InlineWordInput.jsx
+++ b/src/components/InlineWordInput.jsx
@@ -52,18 +52,26 @@ const InlineWordInput = ({ onSubmit, onCancel, theme, previousWord }) => {
       />
       {suggestions.length > 0 && (
         <div className="absolute left-0 top-full mt-2 flex flex-col gap-2 bg-white p-2 rounded-xl shadow-lg border border-gray-200 z-10">
-          {suggestions.map((sug, idx) => (
-            <button
-              key={idx}
-              onMouseDown={() => {
-                onSubmit(sug);
-                setValue('');
-              }}
-              className={`${theme.button} text-white px-4 py-2 rounded-lg text-xl sm:text-2xl`}
-            >
-              {sug}
-            </button>
-          ))}
+          {suggestions.map((sug, idx) => {
+            const handlePick = () => {
+              onSubmit(sug);
+              setValue('');
+            };
+
+            return (
+              <button
+                key={idx}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handlePick();
+                }}
+                className={`${theme.button} text-white px-4 py-2 rounded-lg text-xl sm:text-2xl`}
+              >
+                {sug}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/SentenceBuilder.jsx
+++ b/src/components/SentenceBuilder.jsx
@@ -80,6 +80,7 @@ const SentenceBuilder = () => {
   });
 
   const [typingPosition, setTypingPosition] = useState(null);
+  const typingPositionRef = useRef(null);
   const suppressNextCancelRef = useRef(false);
   const [showWordMat, setShowWordMat] = useState(false);
 
@@ -311,7 +312,9 @@ const SentenceBuilder = () => {
    */
   const startTyping = (sentenceIndex, wordIndex) => {
     playSound('select');
-    setTypingPosition({ sentenceIndex, wordIndex });
+    const position = { sentenceIndex, wordIndex };
+    setTypingPosition(position);
+    typingPositionRef.current = position;
   };
 
   const cancelTyping = useCallback(() => {
@@ -319,12 +322,14 @@ const SentenceBuilder = () => {
       return;
     }
     setTypingPosition(null);
+    typingPositionRef.current = null;
   }, []);
 
   const insertWord = async (word) => {
-    if (!typingPosition) return;
+    const position = typingPosition ?? typingPositionRef.current;
+    if (!position) return;
     suppressNextCancelRef.current = true;
-    const { sentenceIndex, wordIndex } = typingPosition;
+    const { sentenceIndex, wordIndex } = position;
 
     let type = checkWordInVocabDB(word);
     if (type === 'unknown') {
@@ -337,7 +342,9 @@ const SentenceBuilder = () => {
     const newWord = { word, type, punctuation: '' };
     newSentences[sentenceIndex].words.splice(wordIndex, 0, newWord);
     setSentences(newSentences);
-    setTypingPosition({ sentenceIndex, wordIndex: wordIndex + 1 });
+    const nextPosition = { sentenceIndex, wordIndex: wordIndex + 1 };
+    setTypingPosition(nextPosition);
+    typingPositionRef.current = nextPosition;
     playSound('select');
     setTimeout(() => {
       suppressNextCancelRef.current = false;

--- a/src/components/WordMat.jsx
+++ b/src/components/WordMat.jsx
@@ -28,7 +28,11 @@ const WordMat = ({ open, onClose, vocabulary, onWordClick }) => {
               {vocabulary[cat].map((word, idx) => (
                 <button
                   key={idx}
-                  onClick={() => onWordClick(word)}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    onWordClick(word);
+                  }}
                   className={`text-white px-2 py-1 rounded ${
                     wordClassBackgroundColours[cat.slice(0, -1)] || 'bg-gray-300'
                   }`}


### PR DESCRIPTION
## Summary
- ensure the inline word input keeps its insertion point when selecting suggested words
- preserve the most recent typing position so clicks outside the input can still insert words
- trigger word-mat selections on mouse down while preventing focus changes that cancel typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1a193e2c8322a66a107929fba828